### PR TITLE
feat: initialize NestJS backend foundation

### DIFF
--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get('health')
+  healthCheck(): { status: string; timestamp: string } {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { DatabaseModule } from '../../../database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
+  const port = process.env.PORT ?? 3000;
+  await app.listen(port);
+}
+bootstrap();

--- a/apps/backend/tsconfig.app.json
+++ b/apps/backend/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Sets up the foundational NestJS backend for Sentinel.

- `apps/backend/src/main.ts` - NestJS bootstrap with global API prefix
- `apps/backend/src/app.module.ts` - Root module with DatabaseModule
- `apps/backend/src/app.controller.ts` - Health check at GET /api/health
- `apps/backend/tsconfig.app.json` - Backend TS compiler config

Closes #5