### PR TITLE
feat: add NotificationPreference and AuditLog entities

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,5 +11,35 @@ model User {
   email     String   @unique
   createdAt DateTime @default(now())
 
+  notificationPreferences NotificationPreference[]
+  auditLogs               AuditLog[]
+
   @@map("users")
+}
+
+model NotificationPreference {
+  id              String   @id @default(cuid())
+  userId          String
+  discordEnabled  Boolean  @default(false)
+  telegramEnabled Boolean  @default(false)
+  emailEnabled    Boolean  @default(false)
+  alertTypes      String[]
+  createdAt       DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("notification_preferences")
+}
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  userId    String
+  action    String
+  actor     String
+  metadata  Json?
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("audit_logs")
 }


### PR DESCRIPTION
## Summary

Adds the NotificationPreference and AuditLog entities to the Prisma schema.

- NotificationPreference stores per-user alert delivery preferences (Discord, Telegram, Email, alert types).
- AuditLog tracks system actions with actor, action, and optional metadata.

Closes #28
Closes #29