### PR TITLE
feat: add Alert and Watchlist entities

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,5 +11,37 @@ model User {
   email     String   @unique
   createdAt DateTime @default(now())
 
+  alerts    Alert[]
+  watchlist Watchlist[]
+
   @@map("users")
+}
+
+model Alert {
+  id        String      @id @default(cuid())
+  userId    String
+  message   String
+  severity  String
+  status    String      @default("open")
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("alerts")
+}
+
+model Watchlist {
+  id         String   @id @default(cuid())
+  userId     String
+  label      String
+  address    String
+  assetCode  String?
+  isWallet   Boolean  @default(true)
+  isContract Boolean  @default(false)
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("watchlists")
 }


### PR DESCRIPTION
## Summary

Adds the Alert and Watchlist entities to the Prisma schema.

- Alert stores security alerts with severity level, status tracking, and timestamps.
- Watchlist enables monitoring of wallets, assets, and contracts per user.

Closes #26
Closes #27