### PR TITLE
feat(rbac): implement role-based access control and authorization guards

### DIFF
--- a/src/modules/rbac/decorators/permissions.decorator.ts
+++ b/src/modules/rbac/decorators/permissions.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { Permission } from '../permissions.enum';
+
+export const PERMISSIONS_KEY = 'permissions';
+export const Permissions = (...permissions: Permission[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/src/modules/rbac/decorators/roles.decorator.ts
+++ b/src/modules/rbac/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../roles.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/modules/rbac/guards/rbac.guard.spec.ts
+++ b/src/modules/rbac/guards/rbac.guard.spec.ts
@@ -1,0 +1,120 @@
+import { RbacGuard } from './rbac.guard';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext } from '@nestjs/common';
+import { Role } from '../roles.enum';
+import { Permission } from '../permissions.enum';
+
+describe('RbacGuard', () => {
+  let guard: RbacGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RbacGuard(reflector);
+  });
+
+  const mockExecutionContext = (user: any): ExecutionContext => {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    } as unknown as ExecutionContext;
+  };
+
+  it('should allow access if no roles or permissions are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+
+    const context = mockExecutionContext({ id: 1, roles: [], permissions: [] });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny access if user is not present', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'roles') return [Role.Admin];
+      return undefined;
+    });
+
+    const context = mockExecutionContext(null);
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should allow access if user has required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'roles') return [Role.Admin];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({ id: 1, roles: [Role.Admin], permissions: [] });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny access if user lacks required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'roles') return [Role.Admin];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({ id: 1, roles: [Role.User], permissions: [] });
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should allow access if user has required permission', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'permissions') return [Permission.CreateUser];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({
+      id: 1,
+      roles: [],
+      permissions: [Permission.CreateUser],
+    });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny access if user lacks required permission', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'permissions') return [Permission.CreateUser];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({
+      id: 1,
+      roles: [],
+      permissions: [Permission.ViewDashboard],
+    });
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should allow access if user has both required role and permission', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'roles') return [Role.Admin];
+      if (key === 'permissions') return [Permission.ManageSystem];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({
+      id: 1,
+      roles: [Role.Admin],
+      permissions: [Permission.ManageSystem],
+    });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny access if user has role but lacks permission', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation(key => {
+      if (key === 'roles') return [Role.Admin];
+      if (key === 'permissions') return [Permission.ManageSystem];
+      return undefined;
+    });
+
+    const context = mockExecutionContext({
+      id: 1,
+      roles: [Role.Admin],
+      permissions: [Permission.ViewDashboard],
+    });
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});

--- a/src/modules/rbac/guards/rbac.guard.ts
+++ b/src/modules/rbac/guards/rbac.guard.ts
@@ -1,0 +1,47 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../roles.enum';
+import { Permission } from '../permissions.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { PERMISSIONS_KEY } from '../decorators/permissions.decorator';
+
+@Injectable()
+export class RbacGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    const requiredPermissions = this.reflector.getAllAndOverride<Permission[]>(PERMISSIONS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles && !requiredPermissions) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      return false; // Or throw UnauthorizedException
+    }
+
+    let hasRole = true;
+    let hasPermission = true;
+
+    if (requiredRoles && requiredRoles.length > 0) {
+      hasRole = requiredRoles.some(role => user.roles?.includes(role));
+    }
+
+    if (requiredPermissions && requiredPermissions.length > 0) {
+      hasPermission = requiredPermissions.some(permission =>
+        user.permissions?.includes(permission),
+      );
+    }
+
+    return hasRole && hasPermission;
+  }
+}

--- a/src/modules/rbac/permissions.enum.ts
+++ b/src/modules/rbac/permissions.enum.ts
@@ -1,0 +1,7 @@
+export enum Permission {
+  CreateUser = 'CREATE_USER',
+  DeleteUser = 'DELETE_USER',
+  ViewDashboard = 'VIEW_DASHBOARD',
+  EditProfile = 'EDIT_PROFILE',
+  ManageSystem = 'MANAGE_SYSTEM',
+}

--- a/src/modules/rbac/rbac.module.ts
+++ b/src/modules/rbac/rbac.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RbacGuard } from './guards/rbac.guard';
+
+@Module({
+  providers: [RbacGuard],
+  exports: [RbacGuard],
+})
+export class RbacModule {}

--- a/src/modules/rbac/roles.enum.ts
+++ b/src/modules/rbac/roles.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  Admin = 'ADMIN',
+  Moderator = 'MODERATOR',
+  User = 'USER',
+}


### PR DESCRIPTION
Description:
This PR implements a robust Role-Based Access Control (RBAC) system within `src/modules/rbac/`. It introduces role and permission definitions, a type-safe permission checking utility, and an authorization guard/middleware to protect endpoints from unauthorized access.

Changes Made:

1. Role and Permission Enums

- roles.enum.ts: Defines standard roles like Admin, Moderator, and User.
- permissions.enum.ts: Defines specific permissions like CREATE_USER and VIEW_DASHBOARD.

2. Decorators

- roles.decorator.ts: @Roles(...) decorator to assign required roles to endpoints.
- permissions.decorator.ts: @Permissions(...) decorator to assign required granular permissions.

3. Authorization Guard

- rbac.guard.ts: Implements CanActivate. It checks the route's required roles and permissions against the user object found on the request (request.user.roles and request.user.permissions).

4. Module

- rbac.module.ts: Packages and exports RbacGuard for use in other modules.

Closes #111 