### PR TITLE
fix(governance): resolve test setup and type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "@opentelemetry/sdk-trace-node": "^2.8.0",
         "@opentelemetry/semantic-conventions": "^1.41.1",
         "@prisma/client": "^7.8.0",
-        "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
         "axios": "^1.17.0",
+        "ethers": "^6.17.0",
         "pg": "^8.21.0",
         "react": "^19.2.7",
         "typeorm": "^1.0.0",
@@ -35,6 +35,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
+        "@types/node": "^26.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "eslint": "^8.50.0",
@@ -56,6 +57,12 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2398,6 +2405,30 @@
         "typeorm": "^0.3.0 || ^1.0.0-dev"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3682,11 +3713,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -4278,6 +4310,12 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -5821,6 +5859,55 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ethers": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -11356,9 +11443,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -11723,7 +11811,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -11850,6 +11937,11 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true
+    },
+    "@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="
     },
     "@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -13422,6 +13514,19 @@
       "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "requires": {}
     },
+    "@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "requires": {
+        "@noble/hashes": "1.3.2"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14307,11 +14412,11 @@
       "dev": true
     },
     "@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "requires": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "@types/normalize-package-data": {
@@ -14633,6 +14738,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -15654,6 +15764,40 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "ethers": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+      "requires": {
+        "@adraffy/ens-normalize": "1.11.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.21.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "22.7.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+          "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+          "requires": {
+            "undici-types": "~6.19.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+        },
+        "undici-types": {
+          "version": "6.19.8",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+        }
+      }
     },
     "eventemitter3": {
       "version": "5.0.4",
@@ -19303,9 +19447,9 @@
       "peer": true
     },
     "undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "unrs-resolver": {
       "version": "1.12.2",
@@ -19556,7 +19700,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "@opentelemetry/sdk-trace-node": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@prisma/client": "^7.8.0",
-    "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "axios": "^1.17.0",
+    "ethers": "^6.17.0",
     "pg": "^8.21.0",
     "react": "^19.2.7",
     "typeorm": "^1.0.0",
@@ -87,6 +87,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
+    "@types/node": "^26.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.50.0",
@@ -101,5 +102,13 @@
     "reflect-metadata": "^0.2.2",
     "ts-jest": "^29.4.11",
     "typescript": "^6.0.3"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.test.ts",
+      "**/tests/**/*.test.ts"
+    ]
   }
 }

--- a/src/modules/governance/proposals/ProposalDetector.ts
+++ b/src/modules/governance/proposals/ProposalDetector.ts
@@ -1,0 +1,268 @@
+import { ethers } from 'ethers';
+import { Logger } from '../../../utils/logger';
+import {
+  ProposalDetectionConfig,
+  ProposalEvent,
+  ProposalEventType,
+  ProposalMetadata,
+  ProposalState,
+} from './types';
+
+// Standard Governor Bravo / OZ Governor ABI (proposal lifecycle events)
+const GOVERNOR_ABI = [
+  'event ProposalCreated(uint256 proposalId, address proposer, address[] targets, uint256[] values, string[] signatures, bytes[] calldatas, uint256 startBlock, uint256 endBlock, string description)',
+  'event ProposalCanceled(uint256 proposalId)',
+  'event ProposalQueued(uint256 proposalId, uint256 eta)',
+  'event ProposalExecuted(uint256 proposalId)',
+  'event VoteCast(address indexed voter, uint256 proposalId, uint8 support, uint256 weight, string reason)',
+  'function state(uint256 proposalId) external view returns (uint8)',
+  'function proposals(uint256 proposalId) external view returns (uint256 id, address proposer, uint256 eta, uint256 startBlock, uint256 endBlock, uint256 forVotes, uint256 againstVotes, uint256 abstainVotes, bool canceled, bool executed)',
+];
+
+const STATE_MAP: Record<number, ProposalState> = {
+  0: ProposalState.Pending,
+  1: ProposalState.Active,
+  2: ProposalState.Canceled,
+  3: ProposalState.Defeated,
+  4: ProposalState.Succeeded,
+  5: ProposalState.Queued,
+  6: ProposalState.Expired,
+  7: ProposalState.Executed,
+};
+
+export class ProposalDetector {
+  private contract: ethers.Contract;
+  private logger: Logger;
+  private config: ProposalDetectionConfig;
+  private provider: ethers.Provider;
+
+  constructor(provider: ethers.Provider, config: ProposalDetectionConfig) {
+    this.provider = provider;
+    this.config = config;
+    this.contract = new ethers.Contract(config.governorAddress, GOVERNOR_ABI, provider);
+    this.logger = new Logger('ProposalDetector');
+  }
+
+  /**
+   * Fetch all historical ProposalCreated events from startBlock to latest.
+   */
+  async fetchHistoricalProposals(
+    fromBlock: number,
+    toBlock: number | 'latest' = 'latest',
+  ): Promise<{ metadata: ProposalMetadata; events: ProposalEvent[] }[]> {
+    this.logger.info(`Fetching historical proposals from block ${fromBlock} to ${toBlock}`);
+
+    const filter = this.contract.filters.ProposalCreated();
+    const logs = await this.contract.queryFilter(filter, fromBlock, toBlock);
+
+    const results = await Promise.all(
+      logs.map(log => this.parseCreatedLog(log as ethers.EventLog)),
+    );
+
+    this.logger.info(`Found ${results.length} historical proposals`);
+    return results;
+  }
+
+  /**
+   * Subscribe to live governance events and emit via callbacks.
+   */
+  subscribe(handlers: {
+    onProposalCreated: (metadata: ProposalMetadata, event: ProposalEvent) => Promise<void>;
+    onProposalCanceled: (proposalId: string, event: ProposalEvent) => Promise<void>;
+    onProposalQueued: (proposalId: string, eta: number, event: ProposalEvent) => Promise<void>;
+    onProposalExecuted: (proposalId: string, event: ProposalEvent) => Promise<void>;
+    onVoteCast: (
+      proposalId: string,
+      voter: string,
+      support: number,
+      weight: string,
+      event: ProposalEvent,
+    ) => Promise<void>;
+  }): void {
+    this.logger.info(`Subscribing to governor events at ${this.config.governorAddress}`);
+
+    this.contract.on(
+      'ProposalCreated',
+      async (
+        proposalId,
+        proposer,
+        targets,
+        values,
+        signatures,
+        calldatas,
+        startBlock,
+        endBlock,
+        description,
+        log,
+      ) => {
+        try {
+          const { metadata, events } = await this.parseCreatedLog(log as ethers.EventLog);
+          await handlers.onProposalCreated(metadata, events[0]);
+        } catch (err) {
+          this.logger.error('Error handling ProposalCreated', err);
+        }
+      },
+    );
+
+    this.contract.on('ProposalCanceled', async (proposalId, log) => {
+      try {
+        const event = await this.buildEvent(log as ethers.EventLog, ProposalEventType.Canceled, {
+          proposalId: proposalId.toString(),
+        });
+        await handlers.onProposalCanceled(proposalId.toString(), event);
+      } catch (err) {
+        this.logger.error('Error handling ProposalCanceled', err);
+      }
+    });
+
+    this.contract.on('ProposalQueued', async (proposalId, eta, log) => {
+      try {
+        const event = await this.buildEvent(log as ethers.EventLog, ProposalEventType.Queued, {
+          proposalId: proposalId.toString(),
+          eta: eta.toString(),
+        });
+        await handlers.onProposalQueued(proposalId.toString(), Number(eta), event);
+      } catch (err) {
+        this.logger.error('Error handling ProposalQueued', err);
+      }
+    });
+
+    this.contract.on('ProposalExecuted', async (proposalId, log) => {
+      try {
+        const event = await this.buildEvent(log as ethers.EventLog, ProposalEventType.Executed, {
+          proposalId: proposalId.toString(),
+        });
+        await handlers.onProposalExecuted(proposalId.toString(), event);
+      } catch (err) {
+        this.logger.error('Error handling ProposalExecuted', err);
+      }
+    });
+
+    this.contract.on('VoteCast', async (voter, proposalId, support, weight, reason, log) => {
+      try {
+        const event = await this.buildEvent(log as ethers.EventLog, ProposalEventType.VoteCast, {
+          voter,
+          proposalId: proposalId.toString(),
+          support: Number(support),
+          weight: weight.toString(),
+          reason,
+        });
+        await handlers.onVoteCast(
+          proposalId.toString(),
+          voter,
+          Number(support),
+          weight.toString(),
+          event,
+        );
+      } catch (err) {
+        this.logger.error('Error handling VoteCast', err);
+      }
+    });
+  }
+
+  unsubscribe(): void {
+    this.contract.removeAllListeners();
+    this.logger.info('Unsubscribed from all governor events');
+  }
+
+  /**
+   * Fetch current on-chain state for a proposal.
+   */
+  async getProposalState(proposalId: string): Promise<ProposalState> {
+    const stateNum: number = await this.contract.state(proposalId);
+    return STATE_MAP[stateNum] ?? ProposalState.Pending;
+  }
+
+  /**
+   * Fetch vote tallies for a proposal.
+   */
+  async getProposalVotes(
+    proposalId: string,
+  ): Promise<{ forVotes: string; againstVotes: string; abstainVotes: string }> {
+    const proposal = await this.contract.proposals(proposalId);
+    return {
+      forVotes: proposal.forVotes.toString(),
+      againstVotes: proposal.againstVotes.toString(),
+      abstainVotes: proposal.abstainVotes.toString(),
+    };
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private async parseCreatedLog(
+    log: ethers.EventLog,
+  ): Promise<{ metadata: ProposalMetadata; events: ProposalEvent[] }> {
+    const {
+      proposalId,
+      proposer,
+      targets,
+      values,
+      signatures,
+      calldatas,
+      startBlock,
+      endBlock,
+      description,
+    } = log.args;
+
+    const block = await log.getBlock();
+    const timestamp = new Date(block.timestamp * 1000);
+    const id = proposalId.toString();
+
+    // Parse title from description (markdown convention: first line is # Title)
+    const title = this.extractTitle(description);
+
+    const state = await this.getProposalState(id).catch(() => ProposalState.Pending);
+
+    const metadata: ProposalMetadata = {
+      id,
+      proposer,
+      targets: targets as string[],
+      values: (values as unknown as bigint[]).map(v => v.toString()),
+      signatures: signatures as string[],
+      calldatas: calldatas as string[],
+      startBlock: Number(startBlock),
+      endBlock: Number(endBlock),
+      description,
+      title,
+      state,
+      forVotes: '0',
+      againstVotes: '0',
+      abstainVotes: '0',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      transactionHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+    };
+
+    const event = await this.buildEvent(log, ProposalEventType.Created, {
+      proposalId: id,
+      proposer,
+      title,
+    });
+
+    return { metadata, events: [event] };
+  }
+
+  private async buildEvent(
+    log: ethers.EventLog,
+    eventType: ProposalEventType,
+    data: Record<string, unknown>,
+  ): Promise<ProposalEvent> {
+    const block = await log.getBlock();
+    const proposalId = (data.proposalId as string) ?? 'unknown';
+    return {
+      id: `${proposalId}-${eventType}-${log.transactionHash}`,
+      proposalId,
+      eventType,
+      blockNumber: log.blockNumber,
+      transactionHash: log.transactionHash,
+      timestamp: new Date(block.timestamp * 1000),
+      data,
+    };
+  }
+
+  private extractTitle(description: string): string {
+    const firstLine = description.split('\n')[0].trim();
+    return firstLine.startsWith('#') ? firstLine.replace(/^#+\s*/, '') : firstLine.slice(0, 100);
+  }
+}

--- a/src/modules/governance/proposals/ProposalRepository.ts
+++ b/src/modules/governance/proposals/ProposalRepository.ts
@@ -1,0 +1,207 @@
+import { DataSource, Repository } from 'typeorm';
+import { ProposalEntity } from './entities/ProposalEntity';
+import { ProposalEventEntity } from './entities/ProposalEventEntity';
+import { ProposalMetadata, ProposalEvent, ProposalState } from './types';
+import { Logger } from '../../../utils/logger';
+
+export interface ProposalSearchOptions {
+  state?: ProposalState;
+  proposer?: string;
+  chainId?: number;
+  fromBlock?: number;
+  toBlock?: number;
+  fromDate?: Date;
+  toDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface EventSearchOptions {
+  proposalId?: string;
+  eventType?: string;
+  fromBlock?: number;
+  toBlock?: number;
+  fromDate?: Date;
+  toDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export class ProposalRepository {
+  private proposalRepo: Repository<ProposalEntity>;
+  private eventRepo: Repository<ProposalEventEntity>;
+  private logger: Logger;
+
+  constructor(private dataSource: DataSource) {
+    this.proposalRepo = dataSource.getRepository(ProposalEntity);
+    this.eventRepo = dataSource.getRepository(ProposalEventEntity);
+    this.logger = new Logger('ProposalRepository');
+  }
+
+  // ─── Proposals ───────────────────────────────────────────────────────────────
+
+  async upsertProposal(metadata: ProposalMetadata, chainId: number): Promise<ProposalEntity> {
+    const existing = await this.proposalRepo.findOne({
+      where: { proposalId: metadata.id, chainId },
+    });
+
+    if (existing) {
+      const updated = this.proposalRepo.merge(existing, {
+        state: metadata.state,
+        forVotes: metadata.forVotes,
+        againstVotes: metadata.againstVotes,
+        abstainVotes: metadata.abstainVotes,
+        executedAt: metadata.executedAt,
+        canceledAt: metadata.canceledAt,
+        queuedAt: metadata.queuedAt,
+        eta: metadata.eta,
+        updatedAt: new Date(),
+      });
+      await this.proposalRepo.save(updated);
+      this.logger.debug(`Updated proposal ${metadata.id}`);
+      return updated;
+    }
+
+    const entity = this.proposalRepo.create({
+      proposalId: metadata.id,
+      chainId,
+      proposer: metadata.proposer,
+      targets: metadata.targets,
+      values: metadata.values,
+      signatures: metadata.signatures,
+      calldatas: metadata.calldatas,
+      startBlock: metadata.startBlock,
+      endBlock: metadata.endBlock,
+      description: metadata.description,
+      title: metadata.title,
+      state: metadata.state,
+      forVotes: metadata.forVotes,
+      againstVotes: metadata.againstVotes,
+      abstainVotes: metadata.abstainVotes,
+      transactionHash: metadata.transactionHash,
+      blockNumber: metadata.blockNumber,
+      createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
+    });
+
+    await this.proposalRepo.save(entity);
+    this.logger.info(`Inserted proposal ${metadata.id} (chain ${chainId})`);
+    return entity;
+  }
+
+  async updateProposalState(
+    proposalId: string,
+    chainId: number,
+    state: ProposalState,
+    extra?: Partial<
+      Pick<
+        ProposalMetadata,
+        | 'executedAt'
+        | 'canceledAt'
+        | 'queuedAt'
+        | 'eta'
+        | 'forVotes'
+        | 'againstVotes'
+        | 'abstainVotes'
+      >
+    >,
+  ): Promise<void> {
+    await this.proposalRepo.update(
+      { proposalId, chainId },
+      { state, updatedAt: new Date(), ...extra },
+    );
+    this.logger.debug(`State of proposal ${proposalId} → ${state}`);
+  }
+
+  async findProposal(proposalId: string, chainId: number): Promise<ProposalEntity | null> {
+    return this.proposalRepo.findOne({ where: { proposalId, chainId } });
+  }
+
+  async searchProposals(
+    chainId: number,
+    opts: ProposalSearchOptions = {},
+  ): Promise<{ items: ProposalEntity[]; total: number }> {
+    const qb = this.proposalRepo.createQueryBuilder('p').where('p.chainId = :chainId', { chainId });
+
+    if (opts.state) qb.andWhere('p.state = :state', { state: opts.state });
+    if (opts.proposer) qb.andWhere('p.proposer = :proposer', { proposer: opts.proposer });
+    if (opts.fromBlock) qb.andWhere('p.blockNumber >= :fromBlock', { fromBlock: opts.fromBlock });
+    if (opts.toBlock) qb.andWhere('p.blockNumber <= :toBlock', { toBlock: opts.toBlock });
+    if (opts.fromDate) qb.andWhere('p.createdAt >= :fromDate', { fromDate: opts.fromDate });
+    if (opts.toDate) qb.andWhere('p.createdAt <= :toDate', { toDate: opts.toDate });
+
+    qb.orderBy('p.blockNumber', 'DESC')
+      .skip(opts.offset ?? 0)
+      .take(opts.limit ?? 50);
+
+    const [items, total] = await qb.getManyAndCount();
+    return { items, total };
+  }
+
+  // ─── Events ───────────────────────────────────────────────────────────────────
+
+  async persistEvent(event: ProposalEvent, chainId: number): Promise<ProposalEventEntity> {
+    const exists = await this.eventRepo.findOne({ where: { eventId: event.id } });
+    if (exists) {
+      this.logger.debug(`Event ${event.id} already persisted, skipping`);
+      return exists;
+    }
+
+    const entity = this.eventRepo.create({
+      eventId: event.id,
+      proposalId: event.proposalId,
+      chainId,
+      eventType: event.eventType,
+      blockNumber: event.blockNumber,
+      transactionHash: event.transactionHash,
+      timestamp: event.timestamp,
+      data: event.data,
+    });
+
+    await this.eventRepo.save(entity);
+    this.logger.debug(`Persisted event ${event.id}`);
+    return entity;
+  }
+
+  async searchEvents(
+    chainId: number,
+    opts: EventSearchOptions = {},
+  ): Promise<{ items: ProposalEventEntity[]; total: number }> {
+    const qb = this.eventRepo.createQueryBuilder('e').where('e.chainId = :chainId', { chainId });
+
+    if (opts.proposalId) qb.andWhere('e.proposalId = :proposalId', { proposalId: opts.proposalId });
+    if (opts.eventType) qb.andWhere('e.eventType = :eventType', { eventType: opts.eventType });
+    if (opts.fromBlock) qb.andWhere('e.blockNumber >= :fromBlock', { fromBlock: opts.fromBlock });
+    if (opts.toBlock) qb.andWhere('e.blockNumber <= :toBlock', { toBlock: opts.toBlock });
+    if (opts.fromDate) qb.andWhere('e.timestamp >= :fromDate', { fromDate: opts.fromDate });
+    if (opts.toDate) qb.andWhere('e.timestamp <= :toDate', { toDate: opts.toDate });
+
+    qb.orderBy('e.blockNumber', 'DESC')
+      .skip(opts.offset ?? 0)
+      .take(opts.limit ?? 100);
+
+    const [items, total] = await qb.getManyAndCount();
+    return { items, total };
+  }
+
+  async getEventsForProposal(proposalId: string, chainId: number): Promise<ProposalEventEntity[]> {
+    return this.eventRepo.find({
+      where: { proposalId, chainId },
+      order: { blockNumber: 'ASC' },
+    });
+  }
+
+  /**
+   * Return the highest block number we've seen for this chain,
+   * so the detector knows where to resume on restart.
+   */
+  async getLastIndexedBlock(chainId: number): Promise<number | null> {
+    const result = await this.proposalRepo
+      .createQueryBuilder('p')
+      .select('MAX(p.blockNumber)', 'maxBlock')
+      .where('p.chainId = :chainId', { chainId })
+      .getRawOne<{ maxBlock: number | null }>();
+
+    return result?.maxBlock ?? null;
+  }
+}

--- a/src/modules/governance/proposals/ProposalTracker.ts
+++ b/src/modules/governance/proposals/ProposalTracker.ts
@@ -1,0 +1,144 @@
+import { ethers } from 'ethers';
+import { DataSource } from 'typeorm';
+import { ProposalDetector } from './ProposalDetector';
+import { ProposalRepository } from './ProposalRepository';
+import { ProposalDetectionConfig, ProposalState } from './types';
+import { Logger } from '../../../utils/logger';
+
+const DEFAULT_POLL_INTERVAL_MS = 12_000;
+
+export class ProposalTracker {
+  private detector: ProposalDetector;
+  private repo: ProposalRepository;
+  private logger: Logger;
+  private config: ProposalDetectionConfig;
+  private stateRefreshInterval?: NodeJS.Timer;
+
+  constructor(
+    provider: ethers.Provider,
+    dataSource: DataSource,
+    config: ProposalDetectionConfig,
+    detector?: ProposalDetector, // injectable for testing
+  ) {
+    this.config = config;
+    this.detector = detector ?? new ProposalDetector(provider, config);
+    this.repo = new ProposalRepository(dataSource);
+    this.logger = new Logger(`ProposalTracker[chain=${config.chainId}]`);
+  }
+
+  async start(): Promise<void> {
+    this.logger.info('Starting governance proposal tracker');
+    const lastBlock = await this.repo.getLastIndexedBlock(this.config.chainId);
+    const fromBlock = lastBlock ?? this.config.startBlock ?? 0;
+    await this.backfill(fromBlock);
+    this.subscribeToLiveEvents();
+    this.scheduleStateRefresh();
+    this.logger.info('Proposal tracker running');
+  }
+
+  stop(): void {
+    this.detector.unsubscribe();
+    if (this.stateRefreshInterval) {
+      clearInterval(this.stateRefreshInterval as unknown as number);
+    }
+    this.logger.info('Proposal tracker stopped');
+  }
+
+  private async backfill(fromBlock: number): Promise<void> {
+    this.logger.info(`Backfilling proposals from block ${fromBlock}`);
+    try {
+      const proposals = await this.detector.fetchHistoricalProposals(fromBlock, 'latest');
+      for (const { metadata, events } of proposals) {
+        await this.repo.upsertProposal(metadata, this.config.chainId);
+        for (const event of events) {
+          await this.repo.persistEvent(event, this.config.chainId);
+        }
+      }
+      this.logger.info(`Backfill complete — ${proposals.length} proposals indexed`);
+    } catch (err) {
+      this.logger.error('Backfill failed', err);
+      throw err;
+    }
+  }
+
+  private subscribeToLiveEvents(): void {
+    this.detector.subscribe({
+      onProposalCreated: async (metadata, event) => {
+        this.logger.info(`New proposal detected: #${metadata.id} — "${metadata.title}"`);
+        await this.repo.upsertProposal(metadata, this.config.chainId);
+        await this.repo.persistEvent(event, this.config.chainId);
+      },
+      onProposalCanceled: async (proposalId, event) => {
+        this.logger.info(`Proposal #${proposalId} canceled`);
+        await this.repo.updateProposalState(
+          proposalId,
+          this.config.chainId,
+          ProposalState.Canceled,
+          { canceledAt: event.timestamp },
+        );
+        await this.repo.persistEvent(event, this.config.chainId);
+      },
+      onProposalQueued: async (proposalId, eta, event) => {
+        this.logger.info(`Proposal #${proposalId} queued (eta: ${eta})`);
+        await this.repo.updateProposalState(proposalId, this.config.chainId, ProposalState.Queued, {
+          queuedAt: event.timestamp,
+          eta,
+        });
+        await this.repo.persistEvent(event, this.config.chainId);
+      },
+      onProposalExecuted: async (proposalId, event) => {
+        this.logger.info(`Proposal #${proposalId} executed`);
+        const votes = await this.detector.getProposalVotes(proposalId);
+        await this.repo.updateProposalState(
+          proposalId,
+          this.config.chainId,
+          ProposalState.Executed,
+          { executedAt: event.timestamp, ...votes },
+        );
+        await this.repo.persistEvent(event, this.config.chainId);
+      },
+      onVoteCast: async (proposalId, voter, support, weight, event) => {
+        this.logger.debug(`Vote on #${proposalId}: ${voter} support=${support} weight=${weight}`);
+        const votes = await this.detector.getProposalVotes(proposalId);
+        await this.repo.updateProposalState(
+          proposalId,
+          this.config.chainId,
+          await this.detector.getProposalState(proposalId),
+          votes,
+        );
+        await this.repo.persistEvent(event, this.config.chainId);
+      },
+    });
+  }
+
+  private scheduleStateRefresh(): void {
+    const interval = this.config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.stateRefreshInterval = setInterval(async () => {
+      try {
+        await this.refreshActiveProposalStates();
+      } catch (err) {
+        this.logger.error('State refresh error', err);
+      }
+    }, interval);
+  }
+
+  private async refreshActiveProposalStates(): Promise<void> {
+    const { items } = await this.repo.searchProposals(this.config.chainId, {
+      state: ProposalState.Active,
+      limit: 100,
+    });
+    for (const proposal of items) {
+      const current = await this.detector.getProposalState(proposal.proposalId);
+      if (current !== proposal.state) {
+        this.logger.info(`Proposal #${proposal.proposalId} state: ${proposal.state} → ${current}`);
+        const votes = await this.detector.getProposalVotes(proposal.proposalId);
+        await this.repo.updateProposalState(
+          proposal.proposalId,
+          this.config.chainId,
+          current,
+          votes,
+        );
+      }
+    }
+  }
+}

--- a/src/modules/governance/proposals/entities/ProposalEntity.ts
+++ b/src/modules/governance/proposals/entities/ProposalEntity.ts
@@ -1,0 +1,85 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { ProposalState } from '../types';
+
+@Entity('governance_proposals')
+@Index(['proposalId', 'chainId'], { unique: true })
+@Index(['chainId', 'state'])
+@Index(['chainId', 'proposer'])
+@Index(['chainId', 'blockNumber'])
+export class ProposalEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'proposal_id' })
+  proposalId!: string;
+
+  @Column({ name: 'chain_id' })
+  chainId!: number;
+
+  @Column()
+  proposer!: string;
+
+  @Column('simple-array')
+  targets!: string[];
+
+  @Column('simple-array')
+  values!: string[];
+
+  @Column('simple-array', { nullable: true })
+  signatures!: string[];
+
+  @Column('simple-json')
+  calldatas!: string[];
+
+  @Column({ name: 'start_block' })
+  startBlock!: number;
+
+  @Column({ name: 'end_block' })
+  endBlock!: number;
+
+  @Column('text')
+  description!: string;
+
+  @Column({ length: 255 })
+  title!: string;
+
+  @Column({
+    type: 'varchar',
+    enum: ProposalState,
+    default: ProposalState.Pending,
+  })
+  state!: ProposalState;
+
+  @Column({ name: 'for_votes', default: '0' })
+  forVotes!: string;
+
+  @Column({ name: 'against_votes', default: '0' })
+  againstVotes!: string;
+
+  @Column({ name: 'abstain_votes', default: '0' })
+  abstainVotes!: string;
+
+  @Column({ name: 'transaction_hash' })
+  transactionHash!: string;
+
+  @Column({ name: 'block_number' })
+  blockNumber!: number;
+
+  @Column({ name: 'eta', nullable: true, type: 'int' })
+  eta?: number;
+
+  @Column({ name: 'queued_at', nullable: true, type: 'timestamp' })
+  queuedAt?: Date;
+
+  @Column({ name: 'executed_at', nullable: true, type: 'timestamp' })
+  executedAt?: Date;
+
+  @Column({ name: 'canceled_at', nullable: true, type: 'timestamp' })
+  canceledAt?: Date;
+
+  @Column({ name: 'created_at', type: 'timestamp' })
+  createdAt!: Date;
+
+  @Column({ name: 'updated_at', type: 'timestamp' })
+  updatedAt!: Date;
+}

--- a/src/modules/governance/proposals/entities/ProposalEventEntity.ts
+++ b/src/modules/governance/proposals/entities/ProposalEventEntity.ts
@@ -1,0 +1,41 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { ProposalEventType } from '../types';
+
+@Entity('governance_proposal_events')
+@Index(['eventId'], { unique: true })
+@Index(['chainId', 'proposalId'])
+@Index(['chainId', 'eventType'])
+@Index(['chainId', 'blockNumber'])
+@Index(['chainId', 'timestamp'])
+export class ProposalEventEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'event_id', unique: true })
+  eventId!: string;
+
+  @Column({ name: 'proposal_id' })
+  proposalId!: string;
+
+  @Column({ name: 'chain_id' })
+  chainId!: number;
+
+  @Column({
+    name: 'event_type',
+    type: 'varchar',
+    enum: ProposalEventType,
+  })
+  eventType!: ProposalEventType;
+
+  @Column({ name: 'block_number' })
+  blockNumber!: number;
+
+  @Column({ name: 'transaction_hash' })
+  transactionHash!: string;
+
+  @Column({ type: 'timestamp' })
+  timestamp!: Date;
+
+  @Column({ type: 'simple-json' })
+  data!: Record<string, unknown>;
+}

--- a/src/modules/governance/proposals/index.ts
+++ b/src/modules/governance/proposals/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './ProposalDetector';
+export * from './ProposalRepository';
+export * from './ProposalTracker';
+export { ProposalEntity } from './entities/ProposalEntity';
+export { ProposalEventEntity } from './entities/ProposalEventEntity';

--- a/src/modules/governance/proposals/tests/ProposalTracker.test.ts
+++ b/src/modules/governance/proposals/tests/ProposalTracker.test.ts
@@ -1,0 +1,266 @@
+import { ethers } from 'ethers';
+import { DataSource } from 'typeorm';
+import { ProposalDetector } from '../ProposalDetector';
+import { ProposalRepository } from '../ProposalRepository';
+import { ProposalTracker } from '../ProposalTracker';
+import { ProposalEventType, ProposalMetadata, ProposalState } from '../types';
+
+const CHAIN_ID = 1;
+
+function makeMetadata(overrides: Partial<ProposalMetadata> = {}): ProposalMetadata {
+  return {
+    id: '42',
+    proposer: '0xProposer',
+    targets: ['0xTarget'],
+    values: ['0'],
+    signatures: [''],
+    calldatas: ['0x'],
+    startBlock: 100,
+    endBlock: 200,
+    description: '# Upgrade treasury\nDetails here.',
+    title: 'Upgrade treasury',
+    state: ProposalState.Active,
+    forVotes: '1000',
+    againstVotes: '200',
+    abstainVotes: '50',
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    transactionHash: '0xdeadbeef',
+    blockNumber: 99,
+    ...overrides,
+  };
+}
+
+function makeMockDs(): DataSource {
+  return {
+    getRepository: jest.fn().mockReturnValue({
+      findOne: jest.fn(),
+      create: jest.fn((v: unknown) => v),
+      save: jest.fn(async (v: unknown) => v),
+      merge: jest.fn((existing: unknown, patch: unknown) => ({
+        ...(existing as object),
+        ...(patch as object),
+      })),
+      update: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+        getRawOne: jest.fn().mockResolvedValue({ maxBlock: null }),
+      }),
+    }),
+  } as unknown as DataSource;
+}
+
+// ─── ProposalRepository ───────────────────────────────────────────────────────
+
+describe('ProposalRepository', () => {
+  let repo: ProposalRepository;
+  let ds: DataSource;
+
+  beforeEach(() => {
+    ds = makeMockDs();
+    repo = new ProposalRepository(ds);
+  });
+
+  describe('upsertProposal', () => {
+    it('inserts a new proposal when it does not exist', async () => {
+      const findOne = (ds.getRepository as jest.Mock)().findOne as jest.Mock;
+      findOne.mockResolvedValue(null);
+      const metadata = makeMetadata();
+      await repo.upsertProposal(metadata, CHAIN_ID);
+      const create = (ds.getRepository as jest.Mock)().create as jest.Mock;
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ proposalId: '42', chainId: CHAIN_ID, title: 'Upgrade treasury' }),
+      );
+    });
+
+    it('updates an existing proposal when it already exists', async () => {
+      const existing = makeMetadata({ state: ProposalState.Pending });
+      const findOne = (ds.getRepository as jest.Mock)().findOne as jest.Mock;
+      findOne.mockResolvedValue(existing);
+      await repo.upsertProposal(makeMetadata({ state: ProposalState.Executed }), CHAIN_ID);
+      const merge = (ds.getRepository as jest.Mock)().merge as jest.Mock;
+      expect(merge).toHaveBeenCalledWith(
+        existing,
+        expect.objectContaining({ state: ProposalState.Executed }),
+      );
+    });
+  });
+
+  describe('persistEvent', () => {
+    it('skips duplicate events', async () => {
+      const findOne = (ds.getRepository as jest.Mock)().findOne as jest.Mock;
+      findOne.mockResolvedValue({ eventId: 'exists' });
+      const save = (ds.getRepository as jest.Mock)().save as jest.Mock;
+      await repo.persistEvent(
+        {
+          id: '42-ProposalCreated-0xdeadbeef',
+          proposalId: '42',
+          eventType: ProposalEventType.Created,
+          blockNumber: 99,
+          transactionHash: '0xdeadbeef',
+          timestamp: new Date(),
+          data: {},
+        },
+        CHAIN_ID,
+      );
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it('saves a new event', async () => {
+      const findOne = (ds.getRepository as jest.Mock)().findOne as jest.Mock;
+      findOne.mockResolvedValue(null);
+      const save = (ds.getRepository as jest.Mock)().save as jest.Mock;
+      await repo.persistEvent(
+        {
+          id: '42-ProposalCreated-0xdeadbeef',
+          proposalId: '42',
+          eventType: ProposalEventType.Created,
+          blockNumber: 99,
+          transactionHash: '0xdeadbeef',
+          timestamp: new Date(),
+          data: { proposer: '0xProposer' },
+        },
+        CHAIN_ID,
+      );
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getLastIndexedBlock', () => {
+    it('returns null when no proposals are indexed', async () => {
+      const result = await repo.getLastIndexedBlock(CHAIN_ID);
+      expect(result).toBeNull();
+    });
+
+    it('returns the maximum block number across stored proposals', async () => {
+      (ds.getRepository as jest.Mock)()
+        .createQueryBuilder()
+        .getRawOne.mockResolvedValue({ maxBlock: 1500 });
+      const result = await repo.getLastIndexedBlock(CHAIN_ID);
+      expect(result).toBe(1500);
+    });
+  });
+});
+
+// ─── ProposalTracker ──────────────────────────────────────────────────────────
+
+describe('ProposalTracker', () => {
+  let tracker: ProposalTracker;
+  let mockDetector: jest.Mocked<
+    Pick<
+      ProposalDetector,
+      | 'fetchHistoricalProposals'
+      | 'subscribe'
+      | 'unsubscribe'
+      | 'getProposalState'
+      | 'getProposalVotes'
+    >
+  >;
+  let mockRepo: jest.Mocked<
+    Pick<
+      ProposalRepository,
+      | 'getLastIndexedBlock'
+      | 'upsertProposal'
+      | 'persistEvent'
+      | 'updateProposalState'
+      | 'searchProposals'
+    >
+  >;
+
+  beforeEach(() => {
+    mockDetector = {
+      fetchHistoricalProposals: jest.fn().mockResolvedValue([]),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      getProposalState: jest.fn().mockResolvedValue(ProposalState.Active),
+      getProposalVotes: jest
+        .fn()
+        .mockResolvedValue({ forVotes: '0', againstVotes: '0', abstainVotes: '0' }),
+    };
+
+    mockRepo = {
+      getLastIndexedBlock: jest.fn().mockResolvedValue(null),
+      upsertProposal: jest.fn().mockResolvedValue({}),
+      persistEvent: jest.fn().mockResolvedValue({}),
+      updateProposalState: jest.fn().mockResolvedValue(undefined),
+      searchProposals: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    };
+
+    // Pass mockDetector directly — no real ethers provider needed
+    tracker = new ProposalTracker(
+      {} as ethers.Provider,
+      makeMockDs(),
+      {
+        governorAddress: '0xGovernor',
+        chainId: CHAIN_ID,
+        startBlock: 0,
+        pollIntervalMs: 99_999_999,
+      },
+      mockDetector as unknown as ProposalDetector,
+    );
+    (tracker as unknown as { repo: typeof mockRepo }).repo = mockRepo;
+  });
+
+  afterEach(() => {
+    tracker.stop();
+  });
+
+  it('calls fetchHistoricalProposals on start', async () => {
+    await tracker.start();
+    expect(mockDetector.fetchHistoricalProposals).toHaveBeenCalled();
+  });
+
+  it('resumes from the last indexed block', async () => {
+    (mockRepo.getLastIndexedBlock as jest.Mock).mockResolvedValue(500);
+    await tracker.start();
+    expect(mockDetector.fetchHistoricalProposals).toHaveBeenCalledWith(500, 'latest');
+  });
+
+  it('persists each historical proposal and its events', async () => {
+    const metadata = makeMetadata();
+    (mockDetector.fetchHistoricalProposals as jest.Mock).mockResolvedValue([
+      {
+        metadata,
+        events: [
+          {
+            id: '42-ProposalCreated-0xdeadbeef',
+            proposalId: '42',
+            eventType: ProposalEventType.Created,
+            blockNumber: 99,
+            transactionHash: '0xdeadbeef',
+            timestamp: new Date(),
+            data: {},
+          },
+        ],
+      },
+    ]);
+    await tracker.start();
+    expect(mockRepo.upsertProposal).toHaveBeenCalledWith(metadata, CHAIN_ID);
+    expect(mockRepo.persistEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to live events on start', async () => {
+    await tracker.start();
+    expect(mockDetector.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onProposalCreated: expect.any(Function),
+        onProposalCanceled: expect.any(Function),
+        onProposalQueued: expect.any(Function),
+        onProposalExecuted: expect.any(Function),
+        onVoteCast: expect.any(Function),
+      }),
+    );
+  });
+
+  it('unsubscribes on stop', async () => {
+    await tracker.start();
+    tracker.stop();
+    expect(mockDetector.unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/modules/governance/proposals/types.ts
+++ b/src/modules/governance/proposals/types.ts
@@ -1,0 +1,67 @@
+export enum ProposalState {
+  Pending = 'Pending',
+  Active = 'Active',
+  Canceled = 'Canceled',
+  Defeated = 'Defeated',
+  Succeeded = 'Succeeded',
+  Queued = 'Queued',
+  Expired = 'Expired',
+  Executed = 'Executed',
+}
+
+export enum ProposalEventType {
+  Created = 'ProposalCreated',
+  Canceled = 'ProposalCanceled',
+  Queued = 'ProposalQueued',
+  Executed = 'ProposalExecuted',
+  VoteCast = 'VoteCast',
+}
+
+export interface ProposalCall {
+  target: string;
+  value: string;
+  signature: string;
+  calldata: string;
+}
+
+export interface ProposalMetadata {
+  id: string;
+  proposer: string;
+  targets: string[];
+  values: string[];
+  signatures: string[];
+  calldatas: string[];
+  startBlock: number;
+  endBlock: number;
+  description: string;
+  title: string;
+  state: ProposalState;
+  forVotes: string;
+  againstVotes: string;
+  abstainVotes: string;
+  createdAt: Date;
+  updatedAt: Date;
+  transactionHash: string;
+  blockNumber: number;
+  executedAt?: Date;
+  canceledAt?: Date;
+  queuedAt?: Date;
+  eta?: number; // timestamp for queued execution
+}
+
+export interface ProposalEvent {
+  id: string; // <proposalId>-<eventType>-<txHash>
+  proposalId: string;
+  eventType: ProposalEventType;
+  blockNumber: number;
+  transactionHash: string;
+  timestamp: Date;
+  data: Record<string, unknown>;
+}
+
+export interface ProposalDetectionConfig {
+  governorAddress: string;
+  chainId: number;
+  startBlock?: number;
+  pollIntervalMs?: number;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,15 @@
+export class Logger {
+  constructor(private readonly context: string) {}
+  info(msg: string, ...args: unknown[]) {
+    console.log(`[${this.context}] ${msg}`, ...args);
+  }
+  debug(msg: string, ...args: unknown[]) {
+    console.debug(`[${this.context}] ${msg}`, ...args);
+  }
+  error(msg: string, ...args: unknown[]) {
+    console.error(`[${this.context}] ${msg}`, ...args);
+  }
+  warn(msg: string, ...args: unknown[]) {
+    console.warn(`[${this.context}] ${msg}`, ...args);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
       "@common/*": ["./apps/backend/src/common/*"],
       "@modules/*": ["./apps/backend/src/modules/*"],
       "@integrations/*": ["./apps/backend/src/integrations/*"]
-    },
-    "types": ["node", "jest"]
+    }
   },
   "include": ["apps/backend/**/*", "libs/**/*", "database/**/*"],
   "exclude": ["node_modules", "dist", "apps/dashboard"]


### PR DESCRIPTION
Summary
Implements governance proposal tracking as scoped in #147.

## Changes
- \`ProposalDetector\` — ethers.js listener for \`ProposalCreated\`, \`ProposalCanceled\`, \`ProposalQueued\`, \`ProposalExecuted\`, \`VoteCast\`
- \`ProposalRepository\` — upsert proposals, persist events (idempotent), search by state/proposer/block/date
- \`ProposalTracker\` — orchestrates backfill from last indexed block, live subscriptions, and periodic state polling for block-number-driven transitions
- \`ProposalEntity\` / \`ProposalEventEntity\` — TypeORM tables with appropriate indexes
- Unit tests covering insert, dedup, backfill, and live event handling

## Acceptance Criteria
- [x] Proposals tracked (live + historical backfill)
- [x] Metadata stored (votes, state, lifecycle timestamps, calldata)
- [x] Events searchable (by type, block range, date range, proposalId
closes #147 