### PR TITLE
Feat/113 team invitation system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ ELASTIC_INDEX=sentinel-events
 
 # Notifications
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook-url
+
+# Team Invitations
+# Number of days a pending invitation remains valid before it's treated as expired
+INVITATION_EXPIRATION_DAYS=7
+# Base URL used to build invitation accept links
+FRONTEND_URL=http://localhost:3000

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { ReportsModule } from '../../../src/modules/reports/reports.module';
 import { ProfileModule } from './modules/profile/profile.module';
 import { PrismaModule } from './database/prisma.module';
 import { IncidentsModule } from './modules/incidents/incidents.module';
+import { InvitationsModule } from './modules/invitations/invitations.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { IncidentsModule } from './modules/incidents/incidents.module';
     ProfileModule,
     IncidentsModule,
     ProtocolHealthModule,
+    InvitationsModule,
   ],
   controllers: [AppController],
 })

--- a/apps/backend/src/modules/invitations/controllers/invitations.controller.ts
+++ b/apps/backend/src/modules/invitations/controllers/invitations.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
+import { AuthenticatedUser } from '../../../common/interfaces/authenticated-user.interface';
+import { AcceptInvitationDto } from '../dto/accept-invitation.dto';
+import { CreateInvitationDto } from '../dto/create-invitation.dto';
+import { QueryInvitationsDto } from '../dto/query-invitations.dto';
+import { ResendInvitationDto } from '../dto/resend-invitation.dto';
+import { InvitationEntity } from '../entities/invitation.entity';
+import { OrgAdminGuard } from '../guards/org-admin.guard';
+import { InvitationAcceptanceService } from '../services/invitation-acceptance.service';
+import { InvitationsService } from '../services/invitations.service';
+
+@ApiTags('invitations')
+@Controller('invitations')
+export class InvitationsController {
+  constructor(
+    private readonly invitationsService: InvitationsService,
+    private readonly acceptanceService: InvitationAcceptanceService,
+  ) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({ summary: 'Invite a new member into an organization' })
+  @ApiResponse({ status: 201, type: InvitationEntity })
+  create(@Body() dto: CreateInvitationDto, @CurrentUser() user: AuthenticatedUser) {
+    return this.invitationsService.create(dto, user);
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({
+    summary: 'List invitations for an organization with pagination, filtering, and sorting',
+  })
+  findAll(@Query() query: QueryInvitationsDto) {
+    return this.invitationsService.findAll(query);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({ summary: 'Retrieve an invitation, including its audit trail' })
+  @ApiResponse({ status: 200, type: InvitationEntity })
+  findOne(@Param('id') id: string) {
+    return this.invitationsService.findOne(id);
+  }
+
+  @Post('accept')
+  @ApiOperation({ summary: 'Accept an invitation using its token, creating an account if needed' })
+  accept(@Body() dto: AcceptInvitationDto) {
+    return this.acceptanceService.accept(dto);
+  }
+
+  @Post(':id/resend')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({ summary: 'Reissue an invitation token and expiration' })
+  resend(
+    @Param('id') id: string,
+    @Body() dto: ResendInvitationDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.invitationsService.resend(id, user, dto.reason);
+  }
+
+  @Patch(':id/revoke')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({ summary: 'Revoke a pending invitation' })
+  revoke(@Param('id') id: string, @CurrentUser() user: AuthenticatedUser) {
+    return this.invitationsService.revoke(id, user);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, OrgAdminGuard)
+  @ApiOperation({ summary: 'Permanently delete an invitation record' })
+  remove(@Param('id') id: string) {
+    return this.invitationsService.remove(id);
+  }
+}

--- a/apps/backend/src/modules/invitations/dto/accept-invitation.dto.ts
+++ b/apps/backend/src/modules/invitations/dto/accept-invitation.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class AcceptInvitationDto {
+  @ApiProperty({ description: 'Raw invitation token, as delivered in the invite link' })
+  @IsString()
+  @MinLength(32)
+  token!: string;
+
+  @ApiProperty({ example: 'new.member@example.com' })
+  @IsEmail()
+  email!: string;
+}

--- a/apps/backend/src/modules/invitations/dto/create-invitation.dto.ts
+++ b/apps/backend/src/modules/invitations/dto/create-invitation.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsEnum, IsString } from 'class-validator';
+import { Role } from '../../../common/enums/role.enum';
+
+export class CreateInvitationDto {
+  @ApiProperty({ description: 'Organization the invitee is being invited into' })
+  @IsString()
+  organizationId!: string;
+
+  @ApiProperty({ example: 'new.member@example.com' })
+  @IsEmail()
+  inviteeEmail!: string;
+
+  @ApiProperty({ enum: Role, example: Role.ANALYST })
+  @IsEnum(Role)
+  role!: Role;
+}

--- a/apps/backend/src/modules/invitations/dto/index.ts
+++ b/apps/backend/src/modules/invitations/dto/index.ts
@@ -1,0 +1,4 @@
+export * from './create-invitation.dto';
+export * from './accept-invitation.dto';
+export * from './resend-invitation.dto';
+export * from './query-invitations.dto';

--- a/apps/backend/src/modules/invitations/dto/query-invitations.dto.ts
+++ b/apps/backend/src/modules/invitations/dto/query-invitations.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsEmail,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { Role } from '../../../common/enums/role.enum';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+
+export class QueryInvitationsDto {
+  @ApiProperty({
+    description: 'Organization to list invitations for (required for authorization scoping)',
+  })
+  @IsString()
+  organizationId!: string;
+
+  @ApiPropertyOptional({ enum: InvitationStatus })
+  @IsOptional()
+  @IsEnum(InvitationStatus)
+  status?: InvitationStatus;
+
+  @ApiPropertyOptional({ enum: Role })
+  @IsOptional()
+  @IsEnum(Role)
+  role?: Role;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEmail()
+  inviteeEmail?: string;
+
+  @ApiPropertyOptional({ description: 'ISO date string, inclusive lower bound on createdAt' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'ISO date string, inclusive upper bound on createdAt' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    enum: ['createdAt', 'updatedAt', 'expiresAt', 'status'],
+    default: 'createdAt',
+  })
+  @IsOptional()
+  @IsIn(['createdAt', 'updatedAt', 'expiresAt', 'status'])
+  sortBy?: 'createdAt' | 'updatedAt' | 'expiresAt' | 'status' = 'createdAt';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/apps/backend/src/modules/invitations/dto/resend-invitation.dto.ts
+++ b/apps/backend/src/modules/invitations/dto/resend-invitation.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ResendInvitationDto {
+  @ApiPropertyOptional({ description: 'Optional note recorded in the audit log for this resend' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/apps/backend/src/modules/invitations/entities/invitation.entity.ts
+++ b/apps/backend/src/modules/invitations/entities/invitation.entity.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '../../../common/enums/role.enum';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+
+export class InvitationEntity {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  organizationId!: string;
+
+  @ApiProperty()
+  inviteeEmail!: string;
+
+  @ApiProperty({ enum: Role })
+  role!: Role;
+
+  @ApiProperty({ enum: InvitationStatus })
+  status!: InvitationStatus;
+
+  @ApiProperty()
+  expiresAt!: Date;
+
+  @ApiProperty()
+  invitedById!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  acceptedAt?: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  revokedAt?: Date | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}
+
+/**
+ * Data shape for a future email/notification integration. Not sent anywhere yet —
+ * assembled by InvitationsService.create() so wiring up delivery later is a
+ * matter of passing this to an EmailService, not redesigning the payload.
+ */
+export class InvitationDeliveryPayload {
+  @ApiProperty()
+  organizationName!: string;
+
+  @ApiProperty()
+  inviterName!: string;
+
+  @ApiProperty({ enum: Role })
+  role!: Role;
+
+  @ApiProperty()
+  invitationLink!: string;
+
+  @ApiProperty()
+  expiresAt!: Date;
+}

--- a/apps/backend/src/modules/invitations/enums/index.ts
+++ b/apps/backend/src/modules/invitations/enums/index.ts
@@ -1,0 +1,2 @@
+export * from './invitation-status.enum';
+export * from './invitation-audit-action.enum';

--- a/apps/backend/src/modules/invitations/enums/invitation-audit-action.enum.ts
+++ b/apps/backend/src/modules/invitations/enums/invitation-audit-action.enum.ts
@@ -1,0 +1,7 @@
+export enum InvitationAuditAction {
+  CREATED = 'invitation_created',
+  RESENT = 'invitation_resent',
+  ACCEPTED = 'invitation_accepted',
+  REVOKED = 'invitation_revoked',
+  EXPIRED = 'invitation_expired',
+}

--- a/apps/backend/src/modules/invitations/enums/invitation-status.enum.ts
+++ b/apps/backend/src/modules/invitations/enums/invitation-status.enum.ts
@@ -1,0 +1,6 @@
+export enum InvitationStatus {
+  PENDING = 'pending',
+  ACCEPTED = 'accepted',
+  EXPIRED = 'expired',
+  REVOKED = 'revoked',
+}

--- a/apps/backend/src/modules/invitations/guards/org-admin.guard.ts
+++ b/apps/backend/src/modules/invitations/guards/org-admin.guard.ts
@@ -1,0 +1,61 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Role } from '../../../common/enums/role.enum';
+import { AuthenticatedUser } from '../../../common/interfaces/authenticated-user.interface';
+import { PrismaService } from '../../../database/prisma.service';
+import { InvitationsRepository } from '../repositories/invitations.repository';
+
+/**
+ * Requires the caller to hold an ADMIN Membership in the target organization.
+ * Resolves the organization either directly (body/query.organizationId, for
+ * create/list) or indirectly via the invitation referenced by :id (for
+ * resend/revoke/delete), since those routes don't carry organizationId themselves.
+ */
+@Injectable()
+export class OrgAdminGuard implements CanActivate {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly invitationsRepository: InvitationsRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user: AuthenticatedUser | undefined = request.user;
+
+    if (!user) {
+      throw new ForbiddenException('Authentication required');
+    }
+
+    const organizationId = await this.resolveOrganizationId(request);
+    if (!organizationId) {
+      throw new ForbiddenException('organizationId is required');
+    }
+
+    const membership = await this.prisma.membership.findUnique({
+      where: { organizationId_userId: { organizationId, userId: user.userId } },
+    });
+
+    if (!membership || membership.role !== Role.ADMIN) {
+      throw new ForbiddenException('Only organization admins can manage invitations');
+    }
+
+    return true;
+  }
+
+  private async resolveOrganizationId(request: {
+    body?: { organizationId?: string };
+    query?: { organizationId?: string };
+    params?: { id?: string };
+  }): Promise<string | undefined> {
+    if (request.body?.organizationId) {
+      return request.body.organizationId;
+    }
+    if (request.query?.organizationId) {
+      return request.query.organizationId;
+    }
+    if (request.params?.id) {
+      const invitation = await this.invitationsRepository.findById(request.params.id);
+      return invitation?.organizationId;
+    }
+    return undefined;
+  }
+}

--- a/apps/backend/src/modules/invitations/interfaces/index.ts
+++ b/apps/backend/src/modules/invitations/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './invitation-filter.interface';
+export * from './paginated-result.interface';

--- a/apps/backend/src/modules/invitations/interfaces/invitation-filter.interface.ts
+++ b/apps/backend/src/modules/invitations/interfaces/invitation-filter.interface.ts
@@ -1,0 +1,21 @@
+import { InvitationStatus } from '../enums/invitation-status.enum';
+import { Role } from '../../../common/enums/role.enum';
+
+export interface InvitationFilter {
+  organizationId?: string;
+  status?: InvitationStatus;
+  role?: Role;
+  inviteeEmail?: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+export interface InvitationPagination {
+  page: number;
+  limit: number;
+}
+
+export interface InvitationSort {
+  sortBy: 'createdAt' | 'updatedAt' | 'expiresAt' | 'status';
+  sortOrder: 'asc' | 'desc';
+}

--- a/apps/backend/src/modules/invitations/interfaces/paginated-result.interface.ts
+++ b/apps/backend/src/modules/invitations/interfaces/paginated-result.interface.ts
@@ -1,0 +1,9 @@
+export interface PaginatedResult<T> {
+  items: T[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}

--- a/apps/backend/src/modules/invitations/invitations.module.ts
+++ b/apps/backend/src/modules/invitations/invitations.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { InvitationsController } from './controllers/invitations.controller';
+import { OrgAdminGuard } from './guards/org-admin.guard';
+import { InvitationsRepository } from './repositories/invitations.repository';
+import { InvitationAcceptanceService } from './services/invitation-acceptance.service';
+import { InvitationTokenService } from './services/invitation-token.service';
+import { InvitationsService } from './services/invitations.service';
+
+@Module({
+  imports: [
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  controllers: [InvitationsController],
+  providers: [
+    InvitationsRepository,
+    InvitationTokenService,
+    InvitationsService,
+    InvitationAcceptanceService,
+    OrgAdminGuard,
+  ],
+  exports: [InvitationsService],
+})
+export class InvitationsModule {}

--- a/apps/backend/src/modules/invitations/repositories/invitations.repository.ts
+++ b/apps/backend/src/modules/invitations/repositories/invitations.repository.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../database/prisma.service';
+import { InvitationAuditAction } from '../enums/invitation-audit-action.enum';
+import { InvitationFilter, InvitationPagination, InvitationSort } from '../interfaces';
+import { PaginatedResult } from '../interfaces/paginated-result.interface';
+
+@Injectable()
+export class InvitationsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(data: Prisma.InvitationCreateInput) {
+    return this.prisma.invitation.create({ data });
+  }
+
+  findById(id: string) {
+    return this.prisma.invitation.findUnique({ where: { id } });
+  }
+
+  findByTokenHash(tokenHash: string) {
+    return this.prisma.invitation.findUnique({ where: { tokenHash } });
+  }
+
+  findPendingByOrgAndEmail(organizationId: string, inviteeEmail: string) {
+    return this.prisma.invitation.findFirst({
+      where: { organizationId, inviteeEmail, status: 'pending' },
+    });
+  }
+
+  async findMany(
+    filter: InvitationFilter,
+    pagination: InvitationPagination,
+    sort: InvitationSort,
+  ): Promise<PaginatedResult<Prisma.InvitationGetPayload<Record<string, never>>>> {
+    const where = this.buildWhere(filter);
+    const { page, limit } = pagination;
+
+    const [items, total] = await Promise.all([
+      this.prisma.invitation.findMany({
+        where,
+        orderBy: { [sort.sortBy]: sort.sortOrder },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.invitation.count({ where }),
+    ]);
+
+    return {
+      items,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  update(id: string, data: Prisma.InvitationUpdateInput) {
+    return this.prisma.invitation.update({ where: { id }, data });
+  }
+
+  delete(id: string) {
+    return this.prisma.invitation.delete({ where: { id } });
+  }
+
+  addAuditEntry(entry: {
+    invitationId: string;
+    action: InvitationAuditAction;
+    actorId?: string | null;
+    actorEmail?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }) {
+    return this.prisma.invitationAuditLog.create({
+      data: {
+        invitationId: entry.invitationId,
+        action: entry.action,
+        actorId: entry.actorId ?? undefined,
+        actorEmail: entry.actorEmail ?? undefined,
+        metadata: (entry.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+      },
+    });
+  }
+
+  findAuditTrail(invitationId: string) {
+    return this.prisma.invitationAuditLog.findMany({
+      where: { invitationId },
+      orderBy: { timestamp: 'asc' },
+    });
+  }
+
+  private buildWhere(filter: InvitationFilter): Prisma.InvitationWhereInput {
+    const where: Prisma.InvitationWhereInput = {};
+
+    if (filter.organizationId) where.organizationId = filter.organizationId;
+    if (filter.status) where.status = filter.status;
+    if (filter.role) where.role = filter.role;
+    if (filter.inviteeEmail) where.inviteeEmail = filter.inviteeEmail;
+
+    if (filter.dateFrom || filter.dateTo) {
+      where.createdAt = {
+        ...(filter.dateFrom ? { gte: filter.dateFrom } : {}),
+        ...(filter.dateTo ? { lte: filter.dateTo } : {}),
+      };
+    }
+
+    return where;
+  }
+}

--- a/apps/backend/src/modules/invitations/services/invitation-acceptance.service.ts
+++ b/apps/backend/src/modules/invitations/services/invitation-acceptance.service.ts
@@ -1,0 +1,82 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../database/prisma.service';
+import { AcceptInvitationDto } from '../dto/accept-invitation.dto';
+import { InvitationAuditAction } from '../enums/invitation-audit-action.enum';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+import { InvitationsRepository } from '../repositories/invitations.repository';
+import { InvitationTokenService } from './invitation-token.service';
+import { InvitationsService } from './invitations.service';
+
+@Injectable()
+export class InvitationAcceptanceService {
+  constructor(
+    private readonly repository: InvitationsRepository,
+    private readonly tokenService: InvitationTokenService,
+    private readonly invitationsService: InvitationsService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async accept(dto: AcceptInvitationDto) {
+    const tokenHash = this.tokenService.hash(dto.token);
+    const invitation = await this.repository.findByTokenHash(tokenHash);
+
+    if (!invitation) {
+      throw new BadRequestException('Invalid invitation token');
+    }
+
+    const effective = await this.invitationsService.deriveEffectiveStatus(invitation);
+
+    if (effective.status === InvitationStatus.ACCEPTED) {
+      throw new BadRequestException('This invitation has already been accepted');
+    }
+    if (effective.status === InvitationStatus.REVOKED) {
+      throw new BadRequestException('This invitation has been revoked');
+    }
+    if (effective.status === InvitationStatus.EXPIRED) {
+      throw new BadRequestException('This invitation has expired');
+    }
+
+    if (effective.inviteeEmail.toLowerCase() !== dto.email.toLowerCase()) {
+      throw new BadRequestException('Email does not match the invited address');
+    }
+
+    const user = await this.findOrCreateUser(dto.email);
+
+    await this.prisma.membership.upsert({
+      where: {
+        organizationId_userId: {
+          organizationId: effective.organizationId,
+          userId: user.id,
+        },
+      },
+      update: { role: effective.role },
+      create: {
+        organizationId: effective.organizationId,
+        userId: user.id,
+        role: effective.role,
+      },
+    });
+
+    const updated = await this.repository.update(effective.id, {
+      status: InvitationStatus.ACCEPTED,
+      acceptedAt: new Date(),
+    });
+
+    await this.repository.addAuditEntry({
+      invitationId: effective.id,
+      action: InvitationAuditAction.ACCEPTED,
+      actorId: user.id,
+      actorEmail: user.email,
+    });
+
+    return { invitation: updated, user };
+  }
+
+  private async findOrCreateUser(email: string) {
+    const existing = await this.prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return existing;
+    }
+    return this.prisma.user.create({ data: { email } });
+  }
+}

--- a/apps/backend/src/modules/invitations/services/invitation-token.service.ts
+++ b/apps/backend/src/modules/invitations/services/invitation-token.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+
+const TOKEN_BYTES = 32;
+
+@Injectable()
+export class InvitationTokenService {
+  generate(): string {
+    return randomBytes(TOKEN_BYTES).toString('hex');
+  }
+
+  hash(rawToken: string): string {
+    return createHash('sha256').update(rawToken).digest('hex');
+  }
+}

--- a/apps/backend/src/modules/invitations/services/invitations.service.ts
+++ b/apps/backend/src/modules/invitations/services/invitations.service.ts
@@ -1,0 +1,213 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../database/prisma.service';
+import { AuthenticatedUser } from '../../../common/interfaces/authenticated-user.interface';
+import { CreateInvitationDto } from '../dto/create-invitation.dto';
+import { QueryInvitationsDto } from '../dto/query-invitations.dto';
+import { InvitationAuditAction } from '../enums/invitation-audit-action.enum';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+import { InvitationDeliveryPayload } from '../entities/invitation.entity';
+import { InvitationsRepository } from '../repositories/invitations.repository';
+import { InvitationTokenService } from './invitation-token.service';
+
+const DEFAULT_EXPIRATION_DAYS = 7;
+
+type InvitationRecord = Prisma.InvitationGetPayload<Record<string, never>>;
+
+@Injectable()
+export class InvitationsService {
+  constructor(
+    private readonly repository: InvitationsRepository,
+    private readonly tokenService: InvitationTokenService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async create(dto: CreateInvitationDto, actor: AuthenticatedUser) {
+    const existing = await this.repository.findPendingByOrgAndEmail(
+      dto.organizationId,
+      dto.inviteeEmail,
+    );
+    if (existing && !this.isExpired(existing)) {
+      throw new ConflictException(
+        `A pending invitation already exists for "${dto.inviteeEmail}" in this organization`,
+      );
+    }
+
+    const rawToken = this.tokenService.generate();
+    const expiresAt = this.computeExpiresAt();
+
+    const invitation = await this.repository.create({
+      organization: { connect: { id: dto.organizationId } },
+      inviteeEmail: dto.inviteeEmail,
+      role: dto.role,
+      status: InvitationStatus.PENDING,
+      tokenHash: this.tokenService.hash(rawToken),
+      expiresAt,
+      invitedBy: { connect: { id: actor.userId } },
+    });
+
+    await this.repository.addAuditEntry({
+      invitationId: invitation.id,
+      action: InvitationAuditAction.CREATED,
+      actorId: actor.userId,
+      actorEmail: actor.email,
+      metadata: { inviteeEmail: dto.inviteeEmail, role: dto.role },
+    });
+
+    const delivery = await this.buildDeliveryPayload(invitation, rawToken, actor);
+
+    return { invitation, token: rawToken, delivery };
+  }
+
+  async findAll(query: QueryInvitationsDto) {
+    const result = await this.repository.findMany(
+      {
+        organizationId: query.organizationId,
+        status: query.status,
+        role: query.role,
+        inviteeEmail: query.inviteeEmail,
+        dateFrom: query.dateFrom ? new Date(query.dateFrom) : undefined,
+        dateTo: query.dateTo ? new Date(query.dateTo) : undefined,
+      },
+      { page: query.page ?? 1, limit: query.limit ?? 20 },
+      { sortBy: query.sortBy ?? 'createdAt', sortOrder: query.sortOrder ?? 'desc' },
+    );
+
+    const items = await Promise.all(result.items.map(item => this.deriveEffectiveStatus(item)));
+    return { ...result, items };
+  }
+
+  async findOne(id: string) {
+    const invitation = await this.repository.findById(id);
+    if (!invitation) {
+      throw new NotFoundException(`Invitation "${id}" not found`);
+    }
+
+    const effective = await this.deriveEffectiveStatus(invitation);
+    const auditTrail = await this.repository.findAuditTrail(id);
+    return { ...effective, auditTrail };
+  }
+
+  async resend(id: string, actor: AuthenticatedUser, reason?: string) {
+    await this.getPendingOrThrow(id);
+
+    const rawToken = this.tokenService.generate();
+    const expiresAt = this.computeExpiresAt();
+
+    const updated = await this.repository.update(id, {
+      tokenHash: this.tokenService.hash(rawToken),
+      expiresAt,
+    });
+
+    await this.repository.addAuditEntry({
+      invitationId: id,
+      action: InvitationAuditAction.RESENT,
+      actorId: actor.userId,
+      actorEmail: actor.email,
+      metadata: reason ? { reason } : undefined,
+    });
+
+    const delivery = await this.buildDeliveryPayload(updated, rawToken, actor);
+
+    return { invitation: updated, token: rawToken, delivery };
+  }
+
+  async revoke(id: string, actor: AuthenticatedUser) {
+    await this.getPendingOrThrow(id);
+
+    const updated = await this.repository.update(id, {
+      status: InvitationStatus.REVOKED,
+      revokedAt: new Date(),
+    });
+
+    await this.repository.addAuditEntry({
+      invitationId: id,
+      action: InvitationAuditAction.REVOKED,
+      actorId: actor.userId,
+      actorEmail: actor.email,
+    });
+
+    return updated;
+  }
+
+  async remove(id: string) {
+    const invitation = await this.repository.findById(id);
+    if (!invitation) {
+      throw new NotFoundException(`Invitation "${id}" not found`);
+    }
+    await this.repository.delete(id);
+  }
+
+  /**
+   * A `pending` invitation past its TTL is treated as expired without a background
+   * job. This persists the transition (and logs it) the first time a stale row is
+   * touched, so status is never stale by more than one read/write cycle.
+   */
+  async deriveEffectiveStatus(invitation: InvitationRecord): Promise<InvitationRecord> {
+    if (invitation.status !== InvitationStatus.PENDING || !this.isExpired(invitation)) {
+      return invitation;
+    }
+
+    const updated = await this.repository.update(invitation.id, {
+      status: InvitationStatus.EXPIRED,
+    });
+
+    await this.repository.addAuditEntry({
+      invitationId: invitation.id,
+      action: InvitationAuditAction.EXPIRED,
+      actorId: null,
+    });
+
+    return updated;
+  }
+
+  private async getPendingOrThrow(id: string): Promise<InvitationRecord> {
+    const invitation = await this.repository.findById(id);
+    if (!invitation) {
+      throw new NotFoundException(`Invitation "${id}" not found`);
+    }
+
+    const effective = await this.deriveEffectiveStatus(invitation);
+    if (effective.status !== InvitationStatus.PENDING) {
+      throw new BadRequestException(
+        `Invitation is "${effective.status}" and can no longer be modified`,
+      );
+    }
+
+    return effective;
+  }
+
+  private async buildDeliveryPayload(
+    invitation: InvitationRecord,
+    rawToken: string,
+    actor: AuthenticatedUser,
+  ): Promise<InvitationDeliveryPayload> {
+    const organization = await this.prisma.organization.findUnique({
+      where: { id: invitation.organizationId },
+    });
+    const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:3000';
+
+    return {
+      organizationName: organization?.name ?? invitation.organizationId,
+      inviterName: actor.name ?? actor.email ?? actor.userId,
+      role: invitation.role as InvitationDeliveryPayload['role'],
+      invitationLink: `${frontendUrl}/invitations/accept?token=${rawToken}`,
+      expiresAt: invitation.expiresAt,
+    };
+  }
+
+  private isExpired(invitation: { expiresAt: Date }): boolean {
+    return invitation.expiresAt.getTime() < Date.now();
+  }
+
+  private computeExpiresAt(): Date {
+    const days = parseInt(process.env.INVITATION_EXPIRATION_DAYS ?? '', 10);
+    const ttlDays = Number.isFinite(days) && days > 0 ? days : DEFAULT_EXPIRATION_DAYS;
+    return new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+  }
+}

--- a/apps/backend/src/modules/invitations/tests/dto-validation.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/dto-validation.spec.ts
@@ -1,0 +1,98 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { Role } from '../../../common/enums/role.enum';
+import { AcceptInvitationDto } from '../dto/accept-invitation.dto';
+import { CreateInvitationDto } from '../dto/create-invitation.dto';
+import { QueryInvitationsDto } from '../dto/query-invitations.dto';
+
+describe('Invitations DTO validation', () => {
+  describe('CreateInvitationDto', () => {
+    it('passes with valid fields', async () => {
+      const dto = plainToInstance(CreateInvitationDto, {
+        organizationId: 'org-1',
+        inviteeEmail: 'new.member@example.com',
+        role: Role.ANALYST,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('fails on an invalid email', async () => {
+      const dto = plainToInstance(CreateInvitationDto, {
+        organizationId: 'org-1',
+        inviteeEmail: 'not-an-email',
+        role: Role.ANALYST,
+      });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'inviteeEmail')).toBe(true);
+    });
+
+    it('fails on an invalid role', async () => {
+      const dto = plainToInstance(CreateInvitationDto, {
+        organizationId: 'org-1',
+        inviteeEmail: 'new.member@example.com',
+        role: 'owner',
+      });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'role')).toBe(true);
+    });
+
+    it('fails when organizationId is missing', async () => {
+      const dto = plainToInstance(CreateInvitationDto, {
+        inviteeEmail: 'new.member@example.com',
+        role: Role.ANALYST,
+      });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'organizationId')).toBe(true);
+    });
+  });
+
+  describe('AcceptInvitationDto', () => {
+    it('passes with a valid token and email', async () => {
+      const dto = plainToInstance(AcceptInvitationDto, {
+        token: 'a'.repeat(64),
+        email: 'new.member@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('fails when the token is too short', async () => {
+      const dto = plainToInstance(AcceptInvitationDto, {
+        token: 'short',
+        email: 'new.member@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'token')).toBe(true);
+    });
+  });
+
+  describe('QueryInvitationsDto', () => {
+    it('fails without organizationId', async () => {
+      const dto = plainToInstance(QueryInvitationsDto, {});
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'organizationId')).toBe(true);
+    });
+
+    it('rejects an invalid status', async () => {
+      const dto = plainToInstance(QueryInvitationsDto, {
+        organizationId: 'org-1',
+        status: 'archived',
+      });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'status')).toBe(true);
+    });
+
+    it('rejects a limit above the maximum', async () => {
+      const dto = plainToInstance(QueryInvitationsDto, { organizationId: 'org-1', limit: 500 });
+      const errors = await validate(dto);
+      expect(errors.some(e => e.property === 'limit')).toBe(true);
+    });
+
+    it('passes with just organizationId (defaults apply)', async () => {
+      const dto = plainToInstance(QueryInvitationsDto, { organizationId: 'org-1' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/invitation-acceptance.service.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/invitation-acceptance.service.spec.ts
@@ -1,0 +1,128 @@
+import { BadRequestException } from '@nestjs/common';
+import { Role } from '../../../common/enums/role.enum';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+import { InvitationAcceptanceService } from '../services/invitation-acceptance.service';
+
+describe('InvitationAcceptanceService', () => {
+  let service: InvitationAcceptanceService;
+
+  const repository = {
+    findByTokenHash: jest.fn(),
+    update: jest.fn(),
+    addAuditEntry: jest.fn(),
+  };
+  const tokenService = {
+    hash: jest.fn().mockReturnValue('hashed-token'),
+  };
+  const invitationsService = {
+    deriveEffectiveStatus: jest.fn(),
+  };
+  const prisma = {
+    user: { findUnique: jest.fn(), create: jest.fn() },
+    membership: { upsert: jest.fn() },
+  };
+
+  const pendingInvitation = {
+    id: 'inv-1',
+    organizationId: 'org-1',
+    inviteeEmail: 'new@example.com',
+    role: Role.ANALYST,
+    status: InvitationStatus.PENDING,
+    expiresAt: new Date(Date.now() + 1000 * 60),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new InvitationAcceptanceService(
+      repository as any,
+      tokenService as any,
+      invitationsService as any,
+      prisma as any,
+    );
+    repository.findByTokenHash.mockResolvedValue(pendingInvitation);
+    invitationsService.deriveEffectiveStatus.mockResolvedValue(pendingInvitation);
+    repository.update.mockResolvedValue({
+      ...pendingInvitation,
+      status: InvitationStatus.ACCEPTED,
+    });
+  });
+
+  it('rejects an unknown token', async () => {
+    repository.findByTokenHash.mockResolvedValue(null);
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'new@example.com' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects when the email does not match the invitee', async () => {
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'someone-else@example.com' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects an already-accepted invitation', async () => {
+    invitationsService.deriveEffectiveStatus.mockResolvedValue({
+      ...pendingInvitation,
+      status: InvitationStatus.ACCEPTED,
+    });
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'new@example.com' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects a revoked invitation', async () => {
+    invitationsService.deriveEffectiveStatus.mockResolvedValue({
+      ...pendingInvitation,
+      status: InvitationStatus.REVOKED,
+    });
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'new@example.com' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects an expired invitation', async () => {
+    invitationsService.deriveEffectiveStatus.mockResolvedValue({
+      ...pendingInvitation,
+      status: InvitationStatus.EXPIRED,
+    });
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'new@example.com' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('creates a new user when none exists for the invitee email, then creates the membership', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.user.create.mockResolvedValue({ id: 'user-new', email: 'new@example.com' });
+
+    const result = await service.accept({ token: 'a'.repeat(64), email: 'new@example.com' });
+
+    expect(prisma.user.create).toHaveBeenCalledWith({ data: { email: 'new@example.com' } });
+    expect(prisma.membership.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId_userId: { organizationId: 'org-1', userId: 'user-new' } },
+        create: { organizationId: 'org-1', userId: 'user-new', role: Role.ANALYST },
+      }),
+    );
+    expect(result.invitation.status).toEqual(InvitationStatus.ACCEPTED);
+  });
+
+  it('reuses an existing user account matching the invitee email', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-existing', email: 'new@example.com' });
+
+    await service.accept({ token: 'a'.repeat(64), email: 'new@example.com' });
+
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.membership.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId_userId: { organizationId: 'org-1', userId: 'user-existing' } },
+      }),
+    );
+  });
+
+  it('matches the invitee email case-insensitively', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-existing', email: 'new@example.com' });
+    await expect(
+      service.accept({ token: 'a'.repeat(64), email: 'NEW@EXAMPLE.COM' }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/invitation-token.service.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/invitation-token.service.spec.ts
@@ -1,0 +1,32 @@
+import { InvitationTokenService } from '../services/invitation-token.service';
+
+describe('InvitationTokenService', () => {
+  let service: InvitationTokenService;
+
+  beforeEach(() => {
+    service = new InvitationTokenService();
+  });
+
+  it('generates a unique token on each call', () => {
+    const a = service.generate();
+    const b = service.generate();
+    expect(a).not.toEqual(b);
+    expect(a).toHaveLength(64); // 32 random bytes, hex-encoded
+  });
+
+  it('hashes deterministically for the same input', () => {
+    const token = service.generate();
+    expect(service.hash(token)).toEqual(service.hash(token));
+  });
+
+  it('produces different hashes for different tokens', () => {
+    const a = service.generate();
+    const b = service.generate();
+    expect(service.hash(a)).not.toEqual(service.hash(b));
+  });
+
+  it('never returns the raw token as its own hash', () => {
+    const token = service.generate();
+    expect(service.hash(token)).not.toEqual(token);
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/invitations.controller.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/invitations.controller.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthenticatedUser } from '../../../common/interfaces/authenticated-user.interface';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
+import { InvitationsController } from '../controllers/invitations.controller';
+import { OrgAdminGuard } from '../guards/org-admin.guard';
+import { InvitationAcceptanceService } from '../services/invitation-acceptance.service';
+import { InvitationsService } from '../services/invitations.service';
+
+describe('InvitationsController', () => {
+  let controller: InvitationsController;
+
+  const invitationsService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    resend: jest.fn(),
+    revoke: jest.fn(),
+    remove: jest.fn(),
+  };
+  const acceptanceService = { accept: jest.fn() };
+  const actor: AuthenticatedUser = { userId: 'admin-1', roles: [] as any };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitationsController],
+      providers: [
+        { provide: InvitationsService, useValue: invitationsService },
+        { provide: InvitationAcceptanceService, useValue: acceptanceService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(OrgAdminGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(InvitationsController);
+  });
+
+  it('delegates create to InvitationsService', async () => {
+    invitationsService.create.mockResolvedValue({ invitation: { id: 'inv-1' } });
+    const dto = { organizationId: 'org-1', inviteeEmail: 'a@example.com', role: 'analyst' } as any;
+    const result = await controller.create(dto, actor);
+    expect(invitationsService.create).toHaveBeenCalledWith(dto, actor);
+    expect(result).toEqual({ invitation: { id: 'inv-1' } });
+  });
+
+  it('delegates findAll to InvitationsService', async () => {
+    invitationsService.findAll.mockResolvedValue({ items: [], meta: {} });
+    const query = { organizationId: 'org-1' } as any;
+    await controller.findAll(query);
+    expect(invitationsService.findAll).toHaveBeenCalledWith(query);
+  });
+
+  it('delegates findOne to InvitationsService', async () => {
+    invitationsService.findOne.mockResolvedValue({ id: 'inv-1' });
+    await controller.findOne('inv-1');
+    expect(invitationsService.findOne).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('delegates accept to InvitationAcceptanceService', async () => {
+    acceptanceService.accept.mockResolvedValue({ invitation: { id: 'inv-1' } });
+    const dto = { token: 'a'.repeat(64), email: 'a@example.com' };
+    await controller.accept(dto);
+    expect(acceptanceService.accept).toHaveBeenCalledWith(dto);
+  });
+
+  it('delegates resend to InvitationsService with the reason', async () => {
+    invitationsService.resend.mockResolvedValue({ token: 'raw' });
+    await controller.resend('inv-1', { reason: 'lost the email' }, actor);
+    expect(invitationsService.resend).toHaveBeenCalledWith('inv-1', actor, 'lost the email');
+  });
+
+  it('delegates revoke to InvitationsService', async () => {
+    invitationsService.revoke.mockResolvedValue({ id: 'inv-1', status: 'revoked' });
+    await controller.revoke('inv-1', actor);
+    expect(invitationsService.revoke).toHaveBeenCalledWith('inv-1', actor);
+  });
+
+  it('delegates remove to InvitationsService', async () => {
+    invitationsService.remove.mockResolvedValue(undefined);
+    await controller.remove('inv-1');
+    expect(invitationsService.remove).toHaveBeenCalledWith('inv-1');
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/invitations.repository.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/invitations.repository.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../database/prisma.service';
+import { InvitationAuditAction } from '../enums/invitation-audit-action.enum';
+import { InvitationsRepository } from '../repositories/invitations.repository';
+
+describe('InvitationsRepository', () => {
+  let repository: InvitationsRepository;
+  const mockPrisma = {
+    invitation: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    invitationAuditLog: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InvitationsRepository, { provide: PrismaService, useValue: mockPrisma }],
+    }).compile();
+
+    repository = module.get(InvitationsRepository);
+  });
+
+  it('creates an invitation via prisma', async () => {
+    mockPrisma.invitation.create.mockResolvedValue({ id: 'inv-1' });
+    const result = await repository.create({ inviteeEmail: 'a@example.com' } as any);
+    expect(mockPrisma.invitation.create).toHaveBeenCalledWith({
+      data: { inviteeEmail: 'a@example.com' },
+    });
+    expect(result).toEqual({ id: 'inv-1' });
+  });
+
+  it('finds a pending invitation for the same org+email', async () => {
+    mockPrisma.invitation.findFirst.mockResolvedValue(null);
+    await repository.findPendingByOrgAndEmail('org-1', 'a@example.com');
+    expect(mockPrisma.invitation.findFirst).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', inviteeEmail: 'a@example.com', status: 'pending' },
+    });
+  });
+
+  it('finds an invitation by token hash', async () => {
+    mockPrisma.invitation.findUnique.mockResolvedValue(null);
+    await repository.findByTokenHash('hash-1');
+    expect(mockPrisma.invitation.findUnique).toHaveBeenCalledWith({
+      where: { tokenHash: 'hash-1' },
+    });
+  });
+
+  it('builds pagination metadata from total count', async () => {
+    mockPrisma.invitation.findMany.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+    mockPrisma.invitation.count.mockResolvedValue(45);
+
+    const result = await repository.findMany(
+      { organizationId: 'org-1' },
+      { page: 2, limit: 20 },
+      { sortBy: 'createdAt', sortOrder: 'desc' },
+    );
+
+    expect(result.meta).toEqual({ total: 45, page: 2, limit: 20, totalPages: 3 });
+    expect(mockPrisma.invitation.findMany).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1' },
+      orderBy: { createdAt: 'desc' },
+      skip: 20,
+      take: 20,
+    });
+  });
+
+  it('writes an audit entry', async () => {
+    mockPrisma.invitationAuditLog.create.mockResolvedValue({ id: 'log-1' });
+    await repository.addAuditEntry({
+      invitationId: 'inv-1',
+      action: InvitationAuditAction.CREATED,
+      actorId: 'user-1',
+      actorEmail: 'admin@example.com',
+    });
+    expect(mockPrisma.invitationAuditLog.create).toHaveBeenCalledWith({
+      data: {
+        invitationId: 'inv-1',
+        action: InvitationAuditAction.CREATED,
+        actorId: 'user-1',
+        actorEmail: 'admin@example.com',
+        metadata: undefined,
+      },
+    });
+  });
+
+  it('records a null actorId for system-driven audit entries', async () => {
+    mockPrisma.invitationAuditLog.create.mockResolvedValue({ id: 'log-1' });
+    await repository.addAuditEntry({
+      invitationId: 'inv-1',
+      action: InvitationAuditAction.EXPIRED,
+      actorId: null,
+    });
+    expect(mockPrisma.invitationAuditLog.create).toHaveBeenCalledWith({
+      data: {
+        invitationId: 'inv-1',
+        action: InvitationAuditAction.EXPIRED,
+        actorId: undefined,
+        actorEmail: undefined,
+        metadata: undefined,
+      },
+    });
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/invitations.service.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/invitations.service.spec.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { Role } from '../../../common/enums/role.enum';
+import { AuthenticatedUser } from '../../../common/interfaces/authenticated-user.interface';
+import { InvitationStatus } from '../enums/invitation-status.enum';
+import { InvitationsService } from '../services/invitations.service';
+
+describe('InvitationsService', () => {
+  let service: InvitationsService;
+  const actor: AuthenticatedUser = {
+    userId: 'admin-1',
+    email: 'admin@example.com',
+    name: 'Admin One',
+    roles: [Role.ADMIN],
+  };
+
+  const repository = {
+    findPendingByOrgAndEmail: jest.fn(),
+    create: jest.fn(),
+    addAuditEntry: jest.fn(),
+    findById: jest.fn(),
+    findMany: jest.fn(),
+    findAuditTrail: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  const tokenService = {
+    generate: jest.fn(),
+    hash: jest.fn(),
+  };
+  const prisma = {
+    organization: { findUnique: jest.fn() },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new InvitationsService(repository as any, tokenService as any, prisma as any);
+    tokenService.generate.mockReturnValue('raw-token');
+    tokenService.hash.mockReturnValue('hashed-token');
+    prisma.organization.findUnique.mockResolvedValue({ id: 'org-1', name: 'Acme Inc' });
+  });
+
+  describe('create', () => {
+    it('creates an invitation and returns the raw token plus a delivery payload', async () => {
+      repository.findPendingByOrgAndEmail.mockResolvedValue(null);
+      repository.create.mockResolvedValue({
+        id: 'inv-1',
+        organizationId: 'org-1',
+        inviteeEmail: 'new@example.com',
+        role: Role.ANALYST,
+        expiresAt: new Date(Date.now() + 1000),
+      });
+
+      const result = await service.create(
+        { organizationId: 'org-1', inviteeEmail: 'new@example.com', role: Role.ANALYST },
+        actor,
+      );
+
+      expect(result.token).toEqual('raw-token');
+      expect(result.delivery.organizationName).toEqual('Acme Inc');
+      expect(result.delivery.invitationLink).toContain('raw-token');
+      expect(repository.addAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ invitationId: 'inv-1', action: 'invitation_created' }),
+      );
+    });
+
+    it('rejects a duplicate pending invitation for the same org+email', async () => {
+      repository.findPendingByOrgAndEmail.mockResolvedValue({
+        id: 'inv-existing',
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      });
+
+      await expect(
+        service.create(
+          { organizationId: 'org-1', inviteeEmail: 'new@example.com', role: Role.ANALYST },
+          actor,
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+
+    it('allows re-inviting once the existing pending invitation has expired', async () => {
+      repository.findPendingByOrgAndEmail.mockResolvedValue({
+        id: 'inv-existing',
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      repository.create.mockResolvedValue({
+        id: 'inv-2',
+        organizationId: 'org-1',
+        inviteeEmail: 'new@example.com',
+        role: Role.ANALYST,
+        expiresAt: new Date(Date.now() + 1000),
+      });
+
+      await expect(
+        service.create(
+          { organizationId: 'org-1', inviteeEmail: 'new@example.com', role: Role.ANALYST },
+          actor,
+        ),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFoundException when the invitation does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(service.findOne('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('flips a stale pending invitation to expired on read', async () => {
+      const staleInvitation = {
+        id: 'inv-1',
+        status: InvitationStatus.PENDING,
+        expiresAt: new Date(Date.now() - 1000),
+      };
+      repository.findById.mockResolvedValue(staleInvitation);
+      repository.update.mockResolvedValue({ ...staleInvitation, status: InvitationStatus.EXPIRED });
+      repository.findAuditTrail.mockResolvedValue([]);
+
+      const result = await service.findOne('inv-1');
+
+      expect(result.status).toEqual(InvitationStatus.EXPIRED);
+      expect(repository.update).toHaveBeenCalledWith('inv-1', { status: InvitationStatus.EXPIRED });
+      expect(repository.addAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'invitation_expired', actorId: null }),
+      );
+    });
+
+    it('leaves a non-expired pending invitation untouched', async () => {
+      const invitation = {
+        id: 'inv-1',
+        status: InvitationStatus.PENDING,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      };
+      repository.findById.mockResolvedValue(invitation);
+      repository.findAuditTrail.mockResolvedValue([]);
+
+      const result = await service.findOne('inv-1');
+
+      expect(result.status).toEqual(InvitationStatus.PENDING);
+      expect(repository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes a pending invitation', async () => {
+      const invitation = {
+        id: 'inv-1',
+        status: InvitationStatus.PENDING,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      };
+      repository.findById.mockResolvedValue(invitation);
+      repository.update.mockResolvedValue({ ...invitation, status: InvitationStatus.REVOKED });
+
+      const result = await service.revoke('inv-1', actor);
+
+      expect(result.status).toEqual(InvitationStatus.REVOKED);
+      expect(repository.addAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'invitation_revoked' }),
+      );
+    });
+
+    it('rejects revoking an already-accepted invitation', async () => {
+      repository.findById.mockResolvedValue({
+        id: 'inv-1',
+        status: InvitationStatus.ACCEPTED,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      });
+
+      await expect(service.revoke('inv-1', actor)).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('resend', () => {
+    it('rotates the token and expiry for a pending invitation', async () => {
+      const invitation = {
+        id: 'inv-1',
+        organizationId: 'org-1',
+        status: InvitationStatus.PENDING,
+        role: Role.ANALYST,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      };
+      repository.findById.mockResolvedValue(invitation);
+      repository.update.mockResolvedValue({ ...invitation, tokenHash: 'hashed-token' });
+
+      const result = await service.resend('inv-1', actor);
+
+      expect(result.token).toEqual('raw-token');
+      expect(repository.addAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'invitation_resent' }),
+      );
+    });
+  });
+});

--- a/apps/backend/src/modules/invitations/tests/org-admin.guard.spec.ts
+++ b/apps/backend/src/modules/invitations/tests/org-admin.guard.spec.ts
@@ -1,0 +1,66 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Role } from '../../../common/enums/role.enum';
+import { OrgAdminGuard } from '../guards/org-admin.guard';
+
+function contextFor(request: unknown): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+describe('OrgAdminGuard', () => {
+  const prisma = { membership: { findUnique: jest.fn() } };
+  const invitationsRepository = { findById: jest.fn() };
+  let guard: OrgAdminGuard;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    guard = new OrgAdminGuard(prisma as any, invitationsRepository as any);
+  });
+
+  it('throws when there is no authenticated user', async () => {
+    await expect(guard.canActivate(contextFor({ body: {} }))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('resolves organizationId from the request body and allows an org admin', async () => {
+    prisma.membership.findUnique.mockResolvedValue({ role: Role.ADMIN });
+    const request = { user: { userId: 'u1' }, body: { organizationId: 'org-1' } };
+    await expect(guard.canActivate(contextFor(request))).resolves.toBe(true);
+    expect(prisma.membership.findUnique).toHaveBeenCalledWith({
+      where: { organizationId_userId: { organizationId: 'org-1', userId: 'u1' } },
+    });
+  });
+
+  it('resolves organizationId from the query string', async () => {
+    prisma.membership.findUnique.mockResolvedValue({ role: Role.ADMIN });
+    const request = { user: { userId: 'u1' }, query: { organizationId: 'org-2' } };
+    await expect(guard.canActivate(contextFor(request))).resolves.toBe(true);
+  });
+
+  it('resolves organizationId by looking up the invitation from :id', async () => {
+    invitationsRepository.findById.mockResolvedValue({ organizationId: 'org-3' });
+    prisma.membership.findUnique.mockResolvedValue({ role: Role.ADMIN });
+    const request = { user: { userId: 'u1' }, params: { id: 'inv-1' } };
+    await expect(guard.canActivate(contextFor(request))).resolves.toBe(true);
+    expect(invitationsRepository.findById).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('rejects a non-admin member', async () => {
+    prisma.membership.findUnique.mockResolvedValue({ role: Role.VIEWER });
+    const request = { user: { userId: 'u1' }, body: { organizationId: 'org-1' } };
+    await expect(guard.canActivate(contextFor(request))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects a user with no membership in the organization', async () => {
+    prisma.membership.findUnique.mockResolvedValue(null);
+    const request = { user: { userId: 'u1' }, body: { organizationId: 'org-1' } };
+    await expect(guard.canActivate(contextFor(request))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects when no organizationId can be resolved at all', async () => {
+    const request = { user: { userId: 'u1' }, body: {} };
+    await expect(guard.canActivate(contextFor(request))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/docs/superpowers/specs/2026-07-20-team-invitation-system-design.md
+++ b/docs/superpowers/specs/2026-07-20-team-invitation-system-design.md
@@ -1,0 +1,212 @@
+# Team Invitation System — Design
+
+Issue: [#113](https://github.com/MD-Creative-Production/Sentinel/issues/113)
+
+## Context & scope note
+
+Issue #113 assumes an existing Organizations Module, Users Module, and RBAC module to
+integrate with, and explicitly lists "Organization creation" as out of scope. In the
+actual codebase:
+
+- `User` has no `role` field and no organization link.
+- Auth is JWT-verification only (`JwtAuthGuard` + `RolesGuard` in `common/`); there is
+  no login/register/AuthModule anywhere, and roles come from JWT claims, not the DB.
+- There is no `Organization` table. The `Incidents` module has a loose, unvalidated
+  `organizationId: String?` field with no relation.
+
+This design adds the minimum real data model needed to make the invitation system's
+acceptance criteria actually mean something (in particular "accepted users are added
+to the correct organization with the assigned role"), while treating full Organization
+CRUD as a separate, future issue. This PR adds `Organization` and `Membership` as data
+models only — no org CRUD endpoints. Organizations/memberships used in tests are seeded
+directly via Prisma.
+
+## Data model
+
+New Prisma models (added to `prisma/schema.prisma`):
+
+```prisma
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+
+  memberships Membership[]
+  invitations Invitation[]
+
+  @@map("organizations")
+}
+
+model Membership {
+  id             String   @id @default(cuid())
+  organizationId String
+  userId         String
+  role           String   // admin | analyst | viewer (existing Role enum values)
+  createdAt      DateTime @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id])
+  user         User         @relation(fields: [userId], references: [id])
+
+  @@unique([organizationId, userId])
+  @@index([userId])
+  @@map("memberships")
+}
+
+model Invitation {
+  id             String    @id @default(cuid())
+  organizationId String
+  inviteeEmail   String
+  role           String    // admin | analyst | viewer
+  status         String    @default("pending") // pending | accepted | expired | revoked
+  tokenHash      String    @unique
+  expiresAt      DateTime
+  invitedById    String
+  acceptedAt     DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  organization Organization         @relation(fields: [organizationId], references: [id])
+  invitedBy    User                 @relation(fields: [invitedById], references: [id])
+  auditEntries InvitationAuditLog[]
+
+  @@index([organizationId])
+  @@index([inviteeEmail])
+  @@index([status])
+  @@map("invitations")
+}
+
+model InvitationAuditLog {
+  id           String   @id @default(cuid())
+  invitationId String
+  action       String   // invitation_created | invitation_resent | invitation_accepted | invitation_revoked | invitation_expired
+  actorId      String?  // null for system-driven actions (automatic expiration)
+  actorEmail   String?
+  metadata     Json?
+  timestamp    DateTime @default(now())
+
+  invitation Invitation @relation(fields: [invitationId], references: [id])
+
+  @@index([invitationId])
+  @@map("invitation_audit_logs")
+}
+```
+
+`User` gains one new back-relation: `memberships Membership[]`. No other `User` columns
+change.
+
+Role values reuse the existing `Role` enum (`admin` | `analyst` | `viewer` from
+`apps/backend/src/common/enums/role.enum.ts`) rather than introducing a second role
+vocabulary. `Membership.role` and `Invitation.role` are both validated against this enum
+at the DTO layer.
+
+Tokens: the raw invitation token is never persisted — only a SHA-256 `tokenHash`,
+mirroring the existing `ApiKey` model's `key`/`keyHash` split. The raw token is returned
+once, in the create response, so a link can be built immediately; email delivery of that
+link is out of scope (per the issue) and is not implemented.
+
+Expiration is derived, not cron-driven (this repo has no `@nestjs/schedule` dependency
+today). A `pending` invitation past `expiresAt` is treated as expired wherever it's
+read (`findOne`, `findAll`, `accept`, `resend`, `revoke`), and its `status` column is
+opportunistically flipped to `expired` (with an `invitation_expired` audit entry, actor
+null) the first time it's touched after expiring. `INVITATION_EXPIRATION_DAYS` (default
+`7`) controls the window, read via `process.env` — consistent with how `JWT_SECRET` is
+read elsewhere in this codebase (there is no `ConfigService` wrapper here).
+
+## Module layout
+
+`apps/backend/src/modules/invitations/`, mirroring the `incidents` module's structure:
+
+```
+invitations/
+├── controllers/invitations.controller.ts
+├── services/
+│   ├── invitations.service.ts            # create, findAll, findOne, resend, revoke, delete
+│   ├── invitation-token.service.ts        # generate/hash/verify tokens
+│   └── invitation-acceptance.service.ts   # accept-invitation workflow
+├── repositories/invitations.repository.ts
+├── dto/
+│   ├── create-invitation.dto.ts
+│   ├── accept-invitation.dto.ts
+│   ├── resend-invitation.dto.ts
+│   ├── query-invitations.dto.ts
+│   └── index.ts
+├── entities/invitation.entity.ts
+├── enums/
+│   ├── invitation-status.enum.ts
+│   ├── invitation-audit-action.enum.ts
+│   └── index.ts
+├── interfaces/
+│   ├── invitation-filter.interface.ts
+│   └── index.ts
+├── guards/org-admin.guard.ts
+├── invitations.module.ts
+└── tests/
+    ├── dto-validation.spec.ts
+    ├── invitation-token.service.spec.ts
+    ├── invitations.repository.spec.ts
+    ├── invitations.service.spec.ts
+    ├── invitation-acceptance.service.spec.ts
+    └── invitations.controller.spec.ts
+```
+
+## Endpoints
+
+| Method | Endpoint                  | Guard                                                            | Notes                                                                              |
+| ------ | ------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| POST   | `/invitations`            | `JwtAuthGuard`, `OrgAdminGuard`                                  | body includes `organizationId`; 409 on duplicate pending invite for same org+email |
+| GET    | `/invitations`            | `JwtAuthGuard`, `OrgAdminGuard` (against `query.organizationId`) | pagination/filter/sort                                                             |
+| GET    | `/invitations/:id`        | `JwtAuthGuard`, `OrgAdminGuard`                                  | 404 if not found                                                                   |
+| POST   | `/invitations/accept`     | public (no guard)                                                | `{ token, email }`                                                                 |
+| POST   | `/invitations/:id/resend` | `JwtAuthGuard`, `OrgAdminGuard`                                  | only from `pending`; rotates token + expiry                                        |
+| PATCH  | `/invitations/:id/revoke` | `JwtAuthGuard`, `OrgAdminGuard`                                  | only from `pending`; 400 on already-accepted                                       |
+| DELETE | `/invitations/:id`        | `JwtAuthGuard`, `OrgAdminGuard`                                  | hard delete, for cleanup                                                           |
+
+**`OrgAdminGuard`** (new, in `invitations/guards/`): reads `organizationId` from
+body/query/param (in that order), loads the caller's `Membership` for that org via
+`CurrentUser().userId`, and requires `role === Role.ADMIN`. No existing guard covers
+org-scoped checks, so this is new rather than reusing `RolesGuard` (which only checks
+the platform-wide JWT role, not per-org membership).
+
+## Business logic
+
+- **create**: reject if a non-expired `pending` invitation already exists for the same
+  `organizationId + inviteeEmail` (409). Generate token via `InvitationTokenService`
+  (32 random bytes, hex-encoded, SHA-256 hash persisted). Write `invitation_created`
+  audit entry. Return the entity plus the one-time raw token and an assembled delivery
+  payload (org name, inviter name, role, invite link, expiry) shaped for a future
+  `EmailService.sendInvitation(...)` call — no email is actually sent.
+- **acceptInvitation**: hash the incoming token, look up by `tokenHash`. Compute
+  effective status; reject with a specific message if expired/revoked/already-accepted/
+  not-found. Verify `email` matches `inviteeEmail` (case-insensitive). Find-or-create the
+  `User` (by email) — no password/auth fields exist on `User`, so this is a plain insert.
+  Upsert a `Membership` (org, user, role from invitation). Mark invitation `accepted`,
+  set `acceptedAt`. Write `invitation_accepted` audit entry. No JWT is issued — this repo
+  has no login/token-issuance code to hook into; that remains a separate concern.
+- **resend**: only from `pending`; rotates token + `expiresAt`; `invitation_resent` audit
+  entry.
+- **revoke**: only from `pending` (400 if already accepted); sets `revoked`,
+  `revokedAt`; `invitation_revoked` audit entry.
+- **findOne/findAll**: run rows through `deriveEffectiveStatus()`, which flips stale
+  `pending` rows to `expired` (persisting the change + `invitation_expired` audit entry,
+  actor `null`) before returning.
+
+## Non-functional
+
+- Pagination/filtering/sorting on `GET /invitations` mirrors `QueryIncidentsDto` exactly
+  (page/limit/sortBy/sortOrder + filters for status, role, inviteeEmail, organizationId,
+  createdAt range, expiresAt range).
+- All endpoints documented via `@ApiTags`/`@ApiOperation`/`@ApiResponse` (Swagger), same
+  as `IncidentsController`.
+- Unit tests per component (token service, repository, services, controller, DTO
+  validation), following the `incidents/tests/` mocking style (mock `PrismaService`,
+  no real DB in unit tests).
+- `npm run lint`, `npm run build`, `npm run test:backend` must all pass before this is
+  considered done.
+
+## Out of scope (explicitly, matching the issue + reality of this codebase)
+
+- Organization CRUD endpoints (data model only).
+- Actual email sending / templates.
+- JWT/session issuance on invitation acceptance.
+- SSO/SAML, external identity providers, bulk import.

--- a/prisma/migrations/20260720190000_add_team_invitation_system/migration.sql
+++ b/prisma/migrations/20260720190000_add_team_invitation_system/migration.sql
@@ -1,0 +1,86 @@
+-- CreateTable
+CREATE TABLE "organizations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "memberships" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "invitations" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "inviteeEmail" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "invitedById" TEXT NOT NULL,
+    "acceptedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "invitations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "invitation_audit_logs" (
+    "id" TEXT NOT NULL,
+    "invitationId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "actorId" TEXT,
+    "actorEmail" TEXT,
+    "metadata" JSONB,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invitation_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "memberships_userId_idx" ON "memberships"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "memberships_organizationId_userId_key" ON "memberships"("organizationId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invitations_tokenHash_key" ON "invitations"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "invitations_organizationId_idx" ON "invitations"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "invitations_inviteeEmail_idx" ON "invitations"("inviteeEmail");
+
+-- CreateIndex
+CREATE INDEX "invitations_status_idx" ON "invitations"("status");
+
+-- CreateIndex
+CREATE INDEX "invitation_audit_logs_invitationId_idx" ON "invitation_audit_logs"("invitationId");
+
+-- AddForeignKey
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_invitedById_fkey" FOREIGN KEY ("invitedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitation_audit_logs" ADD CONSTRAINT "invitation_audit_logs_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "invitations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,27 +7,29 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  createdAt DateTime @default(now())
-  alerts    Alert[]
-  watchlist Watchlist[]
+  id                      String                   @id @default(cuid())
+  email                   String                   @unique
+  createdAt               DateTime                 @default(now())
+  alerts                  Alert[]
+  watchlist               Watchlist[]
   notificationPreferences NotificationPreference[]
   auditLogs               AuditLog[]
   apiKeys                 ApiKey[]
   assignedIncidents       Incident[]
+  memberships             Membership[]
+  invitationsSent         Invitation[]
 
   @@map("users")
 }
 
 model Alert {
-  id        String      @id @default(cuid())
+  id        String   @id @default(cuid())
   userId    String
   message   String
   severity  String
-  status    String      @default("open")
-  createdAt DateTime    @default(now())
-  updatedAt DateTime    @updatedAt
+  status    String   @default("open")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   acknowledgedAt DateTime?
   acknowledgedBy String?
@@ -80,14 +82,14 @@ model AuditLog {
 }
 
 model ApiKey {
-  id          String   @id @default(cuid())
-  userId      String
-  name        String
-  key         String   @unique
-  keyHash     String   @unique
-  lastUsedAt  DateTime?
-  revokedAt   DateTime?
-  createdAt   DateTime @default(now())
+  id         String    @id @default(cuid())
+  userId     String
+  name       String
+  key        String    @unique
+  keyHash    String    @unique
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -104,8 +106,8 @@ model Proposal {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  votes       Vote[]
-  events      GovernanceEvent[]
+  votes  Vote[]
+  events GovernanceEvent[]
 
   @@map("proposals")
 }
@@ -114,25 +116,25 @@ model Vote {
   id         String   @id @default(cuid())
   proposalId String
   voter      String
-  choice     String   // "yes", "no", "abstain"
+  choice     String // "yes", "no", "abstain"
   weight     String
   createdAt  DateTime @default(now())
 
-  proposal   Proposal @relation(fields: [proposalId], references: [id])
+  proposal Proposal @relation(fields: [proposalId], references: [id])
 
   @@map("votes")
 }
 
 model GovernanceEvent {
   id              String   @id @default(cuid())
-  eventType       String   // "proposal_created", "vote_cast"
+  eventType       String // "proposal_created", "vote_cast"
   proposalId      String?
   voter           String?
   transactionHash String   @unique
   metadata        Json?
   createdAt       DateTime @default(now())
 
-  proposal        Proposal? @relation(fields: [proposalId], references: [id])
+  proposal Proposal? @relation(fields: [proposalId], references: [id])
 
   @@map("governance_events")
 }
@@ -142,17 +144,17 @@ model GovernanceEvent {
 // ---------------------------------------------------------------------------
 
 model InvestigationNote {
-  id         String   @id @default(cuid())
+  id         String    @id @default(cuid())
   caseId     String
   authorId   String
   authorName String
   title      String?
   content    String
   tags       String[]
-  deleted    Boolean  @default(false)
+  deleted    Boolean   @default(false)
   deletedAt  DateTime?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 
   auditEntries NoteAuditLog[]
 
@@ -163,7 +165,7 @@ model InvestigationNote {
 model NoteAuditLog {
   id             String   @id @default(cuid())
   noteId         String
-  action         String   // "created" | "updated" | "deleted"
+  action         String // "created" | "updated" | "deleted"
   actorId        String
   actorName      String
   previousValues Json?
@@ -200,7 +202,7 @@ model Incident {
   resolvedAt      DateTime?
   closedAt        DateTime?
 
-  assignedUser User? @relation(fields: [assignedUserId], references: [id])
+  assignedUser User?              @relation(fields: [assignedUserId], references: [id])
   auditEntries IncidentAuditLog[]
 
   @@index([status])
@@ -214,7 +216,7 @@ model Incident {
 model IncidentAuditLog {
   id             String   @id @default(cuid())
   incidentId     String
-  action         String   // incident_created|status_changed|owner_assigned|owner_reassigned|owner_removed|severity_updated|priority_updated|incident_updated|resolved|closed|reopened
+  action         String // incident_created|status_changed|owner_assigned|owner_reassigned|owner_removed|severity_updated|priority_updated|incident_updated|resolved|closed|reopened
   actorId        String
   actorName      String?
   previousValues Json?
@@ -232,33 +234,98 @@ model IncidentAuditLog {
 // ---------------------------------------------------------------------------
 
 model ProtocolHealthMetric {
-  id                     String    @id @default(cuid())
+  id                     String   @id @default(cuid())
   chainId                String
-  timestamp              DateTime  @default(now())
-  transactionCount       Int       @default(0)
-  failedTransactionCount Int       @default(0)
-  contractCallCount      Int       @default(0)
-  contractDeployCount    Int       @default(0)
-  uniqueSenders          Int       @default(0)
-  monitorHealthy         Boolean   @default(true)
+  timestamp              DateTime @default(now())
+  transactionCount       Int      @default(0)
+  failedTransactionCount Int      @default(0)
+  contractCallCount      Int      @default(0)
+  contractDeployCount    Int      @default(0)
+  uniqueSenders          Int      @default(0)
+  monitorHealthy         Boolean  @default(true)
 
   @@index([chainId, timestamp])
   @@map("protocol_health_metrics")
 }
 
 model ProtocolHealthAlert {
-  id          String    @id @default(cuid())
-  chainId     String
-  alertType   String
-  severity    String    @default("medium")
-  status      String    @default("open")
-  message     String
-  metadata    Json?
+  id             String    @id @default(cuid())
+  chainId        String
+  alertType      String
+  severity       String    @default("medium")
+  status         String    @default("open")
+  message        String
+  metadata       Json?
   acknowledgedAt DateTime?
   acknowledgedBy String?
-  createdAt   DateTime  @default(now())
+  createdAt      DateTime  @default(now())
 
   @@index([chainId, status])
   @@index([status])
   @@map("protocol_health_alerts")
+}
+
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+
+  memberships Membership[]
+  invitations Invitation[]
+
+  @@map("organizations")
+}
+
+model Membership {
+  id             String   @id @default(cuid())
+  organizationId String
+  userId         String
+  role           String
+  createdAt      DateTime @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id])
+  user         User         @relation(fields: [userId], references: [id])
+
+  @@unique([organizationId, userId])
+  @@index([userId])
+  @@map("memberships")
+}
+
+model Invitation {
+  id             String    @id @default(cuid())
+  organizationId String
+  inviteeEmail   String
+  role           String
+  status         String    @default("pending")
+  tokenHash      String    @unique
+  expiresAt      DateTime
+  invitedById    String
+  acceptedAt     DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  organization Organization         @relation(fields: [organizationId], references: [id])
+  invitedBy    User                 @relation(fields: [invitedById], references: [id])
+  auditEntries InvitationAuditLog[]
+
+  @@index([organizationId])
+  @@index([inviteeEmail])
+  @@index([status])
+  @@map("invitations")
+}
+
+model InvitationAuditLog {
+  id           String   @id @default(cuid())
+  invitationId String
+  action       String
+  actorId      String?
+  actorEmail   String?
+  metadata     Json?
+  timestamp    DateTime @default(now())
+
+  invitation Invitation @relation(fields: [invitationId], references: [id])
+
+  @@index([invitationId])
+  @@map("invitation_audit_logs")
 }


### PR DESCRIPTION
## Description

Implements the Team Invitation System described in #113: organization admins can invite new members by email with an assigned role, invitees accept via a secure single-use token, and invitations support expiration, revocation, resend, listing (paginated/filtered/sorted), and full audit logging.

The codebase had no Organizations Module, Users Module, or RBAC integration to build on top of (roles only ever lived in JWT claims, and `organizationId` elsewhere in the app was an unvalidated loose string with no backing table). Since the issue's own acceptance criteria require "accepted users are added to the correct organization with the assigned role," this PR adds minimal `Organization` and `Membership` Prisma models as a prerequisite. Organization CRUD itself stays out of scope, matching the issue — organizations/memberships are seeded directly via Prisma in tests, same as they'd need to be seeded in production until a dedicated Organizations module lands.

Key decisions, open to discussion in review:
- Invitation/Membership roles reuse the existing global `Role` enum rather than introducing a second role vocabulary.
- Expiration is derived and opportunistically persisted on read/write instead of a cron job, since `@nestjs/schedule` isn't a dependency in this repo yet.
- `POST /invitations/accept` is public and creates a `User` record if the invitee doesn't have one yet; no session/JWT is issued, since this repo has no login/token-issuance code to hook into.
- A new `OrgAdminGuard` enforces org-scoped `ADMIN` membership, since the existing `RolesGuard` only checks the platform-wide JWT role, not per-organization membership.

Design doc: `docs/superpowers/specs/2026-07-20-team-invitation-system-design.md`

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues

<!-- Link related issues using # -->

Fixes #113
Closes #113 

## Changes Made

<!-- List the specific changes you made -->

- Added `Organization`, `Membership`, `Invitation`, and `InvitationAuditLog` Prisma models, plus a migration
- Added `apps/backend/src/modules/invitations/` module: controller, services (`InvitationsService`, `InvitationTokenService`, `InvitationAcceptanceService`), repository, DTOs, entities, enums, and a new `OrgAdminGuard`
- Endpoints: `POST /invitations`, `GET /invitations`, `GET /invitations/:id`, `POST /invitations/accept`, `POST /invitations/:id/resend`, `PATCH /invitations/:id/revoke`, `DELETE /invitations/:id`
- Secure single-use invitation tokens (SHA-256 hash persisted, raw token returned once), mirroring the existing `ApiKey` key/keyHash pattern
- Lazy/derived expiration handling driven by `INVITATION_EXPIRATION_DAYS` (default 7, documented in `.env.example`), with no new scheduler dependency
- Delivery payload (org name, inviter name, role, invite link, expiry) assembled on create/resend, ready for a future email integration
- Per-invitation audit log covering created/resent/accepted/revoked/expired events
- Registered `InvitationsModule` in `app.module.ts`
- Swagger/OpenAPI documentation on all endpoints
- 51 new unit tests across DTO validation, token service, repository, both services, the controller, and the new guard

## Testing

<!-- Describe the tests you've run and how to reproduce them -->

- [x] I have tested these changes locally
- [x] Tests pass locally (`npm run test`)
- [x] Linting passes (`npm run lint`)
- [x] Code is formatted (`npm run format`)
- [x] TypeScript builds successfully (`npm run build`)

Verified against a local Postgres instance: applied existing migrations, then applied and confirmed the new `add_team_invitation_system` migration runs cleanly and matches the generated Prisma client. Full backend suite: 292/292 tests passing, repo-wide lint 0 errors, `format:check` clean, `build` clean.

## Checklist

<!-- Ensure all items are checked before submitting -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests passed with my changes

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

N/A — backend-only change.

## Additional Context

<!-- Add any other context about the PR -->

This PR intentionally scopes down from the issue's original framing, which assumed pre-existing Organizations/Users/RBAC modules — none exist in this codebase. Rather than silently faking `organizationId` as another unvalidated string (as `Incident` currently does), I added the minimal real data model needed to make the acceptance criteria meaningful. Happy to adjust the Organization/Membership shape if maintainers are already planning a dedicated Organizations module with a different design.
