### PR TITLE
feat: Threat Intelligence Feed Framework

### DIFF
--- a/src/modules/threat-intelligence/interfaces/threat-intelligence.interface.ts
+++ b/src/modules/threat-intelligence/interfaces/threat-intelligence.interface.ts
@@ -1,0 +1,59 @@
+/** Severity level associated with a threat indicator. */
+export type ThreatSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+/** The kind of indicator of compromise (IOC) a record represents. */
+export type ThreatIndicatorType = 'address' | 'domain' | 'ip' | 'hash' | 'url' | 'other';
+
+/**
+ * A single indicator of compromise as reported by a threat intelligence feed,
+ * before it has been ingested and stamped with feed/timing metadata.
+ */
+export interface ThreatIndicator {
+  /** The raw indicator value (address, domain, IP, file hash, URL, etc.). */
+  indicator: string;
+  /** The kind of indicator this record represents. */
+  indicatorType: ThreatIndicatorType;
+  /** Human-readable description of why this indicator is considered malicious. */
+  description: string;
+  /** Severity level assigned to this indicator. */
+  severity: ThreatSeverity;
+  /** Optional upstream source identifier (e.g. report URL, vendor name). */
+  source?: string;
+  /** Optional raw payload from the feed, preserved for auditing. */
+  raw?: Record<string, unknown>;
+}
+
+/**
+ * A threat indicator after ingestion, stamped with the feed it came from
+ * and when it was fetched.
+ */
+export interface ThreatIntelRecord extends ThreatIndicator {
+  /** Unique identifier assigned to this record at ingestion time. */
+  id: string;
+  /** Name of the feed this record was ingested from. */
+  feedName: string;
+  /** ISO-8601 timestamp of when this record was fetched. */
+  fetchedAt: string;
+}
+
+/** Outcome of a single ingestion pass for one feed. */
+export interface FeedIngestionResult {
+  /** Name of the feed that was ingested. */
+  feedName: string;
+  /** Whether the ingestion pass completed without error. */
+  success: boolean;
+  /** Number of records ingested (0 on failure). */
+  recordCount: number;
+  /** Error message, present only when `success` is false. */
+  error?: string;
+  /** ISO-8601 timestamp of when this ingestion pass ran. */
+  ingestedAt: string;
+}
+
+/** Options controlling periodic ingestion scheduling for a feed. */
+export interface ScheduleOptions {
+  /** Interval between automatic ingestion runs, in milliseconds. */
+  intervalMs: number;
+  /** Whether to run an ingestion pass immediately when scheduling starts. */
+  runImmediately?: boolean;
+}

--- a/src/modules/threat-intelligence/threat-intelligence-feed.ts
+++ b/src/modules/threat-intelligence/threat-intelligence-feed.ts
@@ -1,0 +1,22 @@
+import { ThreatIndicator } from './interfaces/threat-intelligence.interface';
+
+/**
+ * Base class all threat intelligence feed adapters must extend.
+ *
+ * This is the feed abstraction: it decouples the ingestion pipeline from the
+ * specifics of any one upstream source (HTTP API, file drop, third-party SDK,
+ * etc.) by requiring only that a feed can name itself and fetch its current
+ * set of indicators.
+ */
+export abstract class ThreatIntelligenceFeed {
+  constructor(public readonly name: string) {}
+
+  /**
+   * Fetch the latest set of threat indicators from this feed's source.
+   *
+   * Implementations should throw on unrecoverable failures — the ingestion
+   * pipeline catches errors per-feed so one failing feed cannot block
+   * ingestion of the others.
+   */
+  abstract fetchIndicators(): Promise<ThreatIndicator[]>;
+}

--- a/src/modules/threat-intelligence/threat-intelligence.module.ts
+++ b/src/modules/threat-intelligence/threat-intelligence.module.ts
@@ -1,0 +1,17 @@
+import { ThreatIntelligenceService } from './threat-intelligence.service';
+
+/**
+ * Module wrapper for the threat intelligence feed framework.
+ * Provides a static helper to instantiate the service.
+ */
+export class ThreatIntelligenceModule {
+  /** Create and configure a ThreatIntelligenceService instance. */
+  static create(): ThreatIntelligenceService {
+    return new ThreatIntelligenceService();
+  }
+}
+
+/** Factory helper function to instantiate the ThreatIntelligenceService. */
+export function createThreatIntelligenceService(): ThreatIntelligenceService {
+  return new ThreatIntelligenceService();
+}

--- a/src/modules/threat-intelligence/threat-intelligence.service.spec.ts
+++ b/src/modules/threat-intelligence/threat-intelligence.service.spec.ts
@@ -1,0 +1,258 @@
+import { ThreatIntelligenceService } from './threat-intelligence.service';
+import { ThreatIntelligenceFeed } from './threat-intelligence-feed';
+import { FeedIngestionResult, ThreatIndicator } from './interfaces/threat-intelligence.interface';
+
+/** Simple in-memory feed used to exercise the framework in tests. */
+class StubFeed extends ThreatIntelligenceFeed {
+  constructor(
+    name: string,
+    public indicators: ThreatIndicator[] = [],
+  ) {
+    super(name);
+  }
+
+  async fetchIndicators(): Promise<ThreatIndicator[]> {
+    return this.indicators;
+  }
+}
+
+/** Feed that always fails, to exercise error handling. */
+class FailingFeed extends ThreatIntelligenceFeed {
+  constructor(
+    name: string,
+    private readonly errorMessage: string,
+  ) {
+    super(name);
+  }
+
+  async fetchIndicators(): Promise<ThreatIndicator[]> {
+    throw new Error(this.errorMessage);
+  }
+}
+
+const sampleIndicator: ThreatIndicator = {
+  indicator: '0xdeadbeef',
+  indicatorType: 'address',
+  description: 'Known drainer contract',
+  severity: 'critical',
+  source: 'TestVendor',
+};
+
+describe('ThreatIntelligenceService', () => {
+  let service: ThreatIntelligenceService;
+
+  beforeEach(() => {
+    service = new ThreatIntelligenceService();
+  });
+
+  afterEach(() => {
+    service.stopAllSchedules();
+    jest.useRealTimers();
+  });
+
+  describe('Feed Abstraction', () => {
+    it('should register a feed and list it', () => {
+      const feed = new StubFeed('FeedA');
+      service.registerFeed(feed);
+
+      expect(service.getRegisteredFeeds()).toEqual(['FeedA']);
+    });
+
+    it('should support multiple distinct feed implementations', () => {
+      service.registerFeed(new StubFeed('FeedA'));
+      service.registerFeed(new FailingFeed('FeedB', 'boom'));
+
+      expect(service.getRegisteredFeeds().sort()).toEqual(['FeedA', 'FeedB']);
+    });
+
+    it('should unregister a feed and discard its records', async () => {
+      service.registerFeed(new StubFeed('FeedA', [sampleIndicator]));
+      await service.ingestFeed('FeedA');
+      expect(service.getRecords('FeedA').length).toBe(1);
+
+      service.unregisterFeed('FeedA');
+
+      expect(service.getRegisteredFeeds()).toEqual([]);
+      expect(service.getRecords('FeedA')).toEqual([]);
+    });
+  });
+
+  describe('Data Ingestion', () => {
+    it('should ingest indicators from a feed and stamp them with feed metadata', async () => {
+      service.registerFeed(new StubFeed('FeedA', [sampleIndicator]));
+
+      const result = await service.ingestFeed('FeedA');
+
+      expect(result.success).toBe(true);
+      expect(result.recordCount).toBe(1);
+
+      const records = service.getRecords('FeedA');
+      expect(records.length).toBe(1);
+      expect(records[0].feedName).toBe('FeedA');
+      expect(records[0].indicator).toBe(sampleIndicator.indicator);
+      expect(records[0].id).toEqual(expect.stringContaining('ti-FeedA-'));
+      expect(records[0].fetchedAt).toBeTruthy();
+    });
+
+    it('should replace previously ingested records for a feed on re-ingestion', async () => {
+      const feed = new StubFeed('FeedA', [sampleIndicator]);
+      service.registerFeed(feed);
+      await service.ingestFeed('FeedA');
+      expect(service.getRecords('FeedA').length).toBe(1);
+
+      // Re-ingest with no indicators this time
+      feed.indicators = [];
+      await service.ingestFeed('FeedA');
+
+      expect(service.getRecords('FeedA').length).toBe(0);
+    });
+
+    it('should return a failed result for an unregistered feed', async () => {
+      const result = await service.ingestFeed('DoesNotExist');
+
+      expect(result.success).toBe(false);
+      expect(result.recordCount).toBe(0);
+      expect(result.error).toContain('not registered');
+    });
+
+    it('should isolate ingestion failures to the failing feed', async () => {
+      service.registerFeed(new StubFeed('GoodFeed', [sampleIndicator]));
+      service.registerFeed(new FailingFeed('BadFeed', 'upstream unavailable'));
+
+      const results = await service.ingestAll();
+      const byFeed = new Map(results.map(r => [r.feedName, r]));
+
+      expect(byFeed.get('GoodFeed')?.success).toBe(true);
+      expect(byFeed.get('GoodFeed')?.recordCount).toBe(1);
+
+      expect(byFeed.get('BadFeed')?.success).toBe(false);
+      expect(byFeed.get('BadFeed')?.error).toBe('upstream unavailable');
+
+      // Good feed's records should still be present despite the other feed failing
+      expect(service.getRecords('GoodFeed').length).toBe(1);
+    });
+
+    it('should aggregate records across all feeds', async () => {
+      service.registerFeed(new StubFeed('FeedA', [sampleIndicator]));
+      service.registerFeed(new StubFeed('FeedB', [{ ...sampleIndicator, indicator: '0xother' }]));
+
+      await service.ingestAll();
+
+      expect(service.getAllRecords().length).toBe(2);
+    });
+
+    it('should notify subscribers of ingestion results, including failures', async () => {
+      const results: FeedIngestionResult[] = [];
+      const unsubscribe = service.onIngestion(result => results.push(result));
+
+      service.registerFeed(new StubFeed('FeedA', [sampleIndicator]));
+      service.registerFeed(new FailingFeed('FeedB', 'nope'));
+      await service.ingestAll();
+
+      expect(results.length).toBe(2);
+      expect(results.some(r => r.feedName === 'FeedA' && r.success)).toBe(true);
+      expect(results.some(r => r.feedName === 'FeedB' && !r.success)).toBe(true);
+
+      unsubscribe();
+      await service.ingestFeed('FeedA');
+      expect(results.length).toBe(2); // No new notifications after unsubscribing
+    });
+  });
+
+  describe('Feed Scheduling', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    it('should run ingestion on the configured interval', async () => {
+      const feed = new StubFeed('FeedA', [sampleIndicator]);
+      const fetchSpy = jest.spyOn(feed, 'fetchIndicators');
+      service.registerFeed(feed);
+
+      service.schedule('FeedA', { intervalMs: 1000 });
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should run an immediate ingestion when runImmediately is set', async () => {
+      const feed = new StubFeed('FeedA', [sampleIndicator]);
+      const fetchSpy = jest.spyOn(feed, 'fetchIndicators');
+      service.registerFeed(feed);
+
+      service.schedule('FeedA', { intervalMs: 1000, runImmediately: true });
+      // Allow the immediate async ingestion to settle
+      await Promise.resolve();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report a feed as scheduled while active and not after stopping', () => {
+      service.registerFeed(new StubFeed('FeedA'));
+
+      expect(service.isScheduled('FeedA')).toBe(false);
+
+      service.schedule('FeedA', { intervalMs: 1000 });
+      expect(service.isScheduled('FeedA')).toBe(true);
+
+      service.stopSchedule('FeedA');
+      expect(service.isScheduled('FeedA')).toBe(false);
+    });
+
+    it('should stop firing ingestion once unscheduled', async () => {
+      const feed = new StubFeed('FeedA', [sampleIndicator]);
+      const fetchSpy = jest.spyOn(feed, 'fetchIndicators');
+      service.registerFeed(feed);
+
+      service.schedule('FeedA', { intervalMs: 1000 });
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      service.stopSchedule('FeedA');
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1); // No further calls
+    });
+
+    it('should replace an existing schedule when re-scheduling the same feed', async () => {
+      const feed = new StubFeed('FeedA', [sampleIndicator]);
+      const fetchSpy = jest.spyOn(feed, 'fetchIndicators');
+      service.registerFeed(feed);
+
+      service.schedule('FeedA', { intervalMs: 1000 });
+      service.schedule('FeedA', { intervalMs: 500 });
+
+      await jest.advanceTimersByTimeAsync(500);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when scheduling a feed that is not registered', () => {
+      expect(() => service.schedule('Unknown', { intervalMs: 1000 })).toThrow(
+        'Cannot schedule unknown feed "Unknown"',
+      );
+    });
+
+    it('should stop all schedules at once', async () => {
+      const feedA = new StubFeed('FeedA', [sampleIndicator]);
+      const feedB = new StubFeed('FeedB', [sampleIndicator]);
+      const spyA = jest.spyOn(feedA, 'fetchIndicators');
+      const spyB = jest.spyOn(feedB, 'fetchIndicators');
+      service.registerFeed(feedA);
+      service.registerFeed(feedB);
+
+      service.schedule('FeedA', { intervalMs: 1000 });
+      service.schedule('FeedB', { intervalMs: 1000 });
+
+      service.stopAllSchedules();
+
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(spyA).not.toHaveBeenCalled();
+      expect(spyB).not.toHaveBeenCalled();
+      expect(service.isScheduled('FeedA')).toBe(false);
+      expect(service.isScheduled('FeedB')).toBe(false);
+    });
+  });
+});

--- a/src/modules/threat-intelligence/threat-intelligence.service.ts
+++ b/src/modules/threat-intelligence/threat-intelligence.service.ts
@@ -1,0 +1,163 @@
+import { ThreatIntelligenceFeed } from './threat-intelligence-feed';
+import {
+  FeedIngestionResult,
+  ScheduleOptions,
+  ThreatIntelRecord,
+} from './interfaces/threat-intelligence.interface';
+
+/**
+ * Core threat intelligence framework: manages registered feed adapters,
+ * ingests their indicators, stores the resulting records, and supports
+ * running ingestion on a recurring schedule.
+ */
+export class ThreatIntelligenceService {
+  private feeds = new Map<string, ThreatIntelligenceFeed>();
+  private records = new Map<string, ThreatIntelRecord[]>();
+  private timers = new Map<string, ReturnType<typeof setInterval>>();
+  private ingestionCallbacks: Array<(result: FeedIngestionResult) => void> = [];
+
+  /** Register a feed adapter with the framework. */
+  public registerFeed(feed: ThreatIntelligenceFeed): void {
+    this.feeds.set(feed.name, feed);
+  }
+
+  /** Remove a feed, stopping any scheduled ingestion and discarding its records. */
+  public unregisterFeed(feedName: string): void {
+    this.stopSchedule(feedName);
+    this.feeds.delete(feedName);
+    this.records.delete(feedName);
+  }
+
+  /** Names of all currently registered feeds. */
+  public getRegisteredFeeds(): string[] {
+    return Array.from(this.feeds.keys());
+  }
+
+  /**
+   * Run a single ingestion pass for one feed. Replaces any previously
+   * ingested records for that feed with the newly fetched set.
+   */
+  public async ingestFeed(feedName: string): Promise<FeedIngestionResult> {
+    const feed = this.feeds.get(feedName);
+    const ingestedAt = new Date().toISOString();
+
+    if (!feed) {
+      const result: FeedIngestionResult = {
+        feedName,
+        success: false,
+        recordCount: 0,
+        error: `Feed "${feedName}" is not registered`,
+        ingestedAt,
+      };
+      this.emitIngestionResult(result);
+      return result;
+    }
+
+    try {
+      const indicators = await feed.fetchIndicators();
+      const records: ThreatIntelRecord[] = indicators.map((indicator, index) => ({
+        ...indicator,
+        id: `ti-${feedName}-${Date.now()}-${index}`,
+        feedName,
+        fetchedAt: ingestedAt,
+      }));
+
+      this.records.set(feedName, records);
+
+      const result: FeedIngestionResult = {
+        feedName,
+        success: true,
+        recordCount: records.length,
+        ingestedAt,
+      };
+      this.emitIngestionResult(result);
+      return result;
+    } catch (error) {
+      const result: FeedIngestionResult = {
+        feedName,
+        success: false,
+        recordCount: 0,
+        error: error instanceof Error ? error.message : String(error),
+        ingestedAt,
+      };
+      this.emitIngestionResult(result);
+      return result;
+    }
+  }
+
+  /** Run an ingestion pass for every registered feed. */
+  public async ingestAll(): Promise<FeedIngestionResult[]> {
+    return Promise.all(this.getRegisteredFeeds().map(name => this.ingestFeed(name)));
+  }
+
+  /** Records currently held for a single feed. */
+  public getRecords(feedName: string): ThreatIntelRecord[] {
+    return this.records.get(feedName) ?? [];
+  }
+
+  /** Records currently held across all feeds. */
+  public getAllRecords(): ThreatIntelRecord[] {
+    return Array.from(this.records.values()).flat();
+  }
+
+  /**
+   * Start periodic ingestion for a feed. Replaces any existing schedule
+   * for the same feed.
+   */
+  public schedule(feedName: string, options: ScheduleOptions): void {
+    if (!this.feeds.has(feedName)) {
+      throw new Error(`Cannot schedule unknown feed "${feedName}"`);
+    }
+    this.stopSchedule(feedName);
+
+    if (options.runImmediately) {
+      void this.ingestFeed(feedName);
+    }
+
+    const timer = setInterval(() => {
+      void this.ingestFeed(feedName);
+    }, options.intervalMs);
+
+    this.timers.set(feedName, timer);
+  }
+
+  /** Stop periodic ingestion for a feed, if it is scheduled. */
+  public stopSchedule(feedName: string): void {
+    const timer = this.timers.get(feedName);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(feedName);
+    }
+  }
+
+  /** Stop every scheduled ingestion job. */
+  public stopAllSchedules(): void {
+    for (const feedName of Array.from(this.timers.keys())) {
+      this.stopSchedule(feedName);
+    }
+  }
+
+  /** Whether a feed currently has an active ingestion schedule. */
+  public isScheduled(feedName: string): boolean {
+    return this.timers.has(feedName);
+  }
+
+  /** Subscribe to ingestion results. Returns an unsubscribe function. */
+  public onIngestion(callback: (result: FeedIngestionResult) => void): () => void {
+    this.ingestionCallbacks.push(callback);
+    return () => {
+      this.ingestionCallbacks = this.ingestionCallbacks.filter(cb => cb !== callback);
+    };
+  }
+
+  private emitIngestionResult(result: FeedIngestionResult): void {
+    for (const callback of this.ingestionCallbacks) {
+      try {
+        callback(result);
+      } catch (error) {
+        // Prevent one faulty callback from aborting others
+        console.error('Error in threat intelligence ingestion callback:', error);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Implements the threat intelligence feed framework requested in #123, under `src/modules/threat-intelligence/`.

## Why
Internal monitoring alone can miss known malicious actors already documented by external threat intel sources. This gives Sentinel a pluggable way to ingest and act on that data.

## Implementation
- **Feed abstraction** — `ThreatIntelligenceFeed` is an abstract base class; any upstream source (HTTP API, file drop, SDK, etc.) implements it by providing a `name` and a `fetchIndicators()` method. The ingestion pipeline only depends on this interface, not on any concrete feed.
- **Data ingestion** — `ThreatIntelligenceService.ingestFeed()` fetches and stores indicators for a single feed, stamping each with an id, feed name, and fetch timestamp. `ingestAll()` runs ingestion across every registered feed in parallel and isolates per-feed failures (one feed throwing doesn't block the others). Ingestion results (success/failure, record count) are observable via `onIngestion()`.
- **Feed scheduling** — `schedule(feedName, { intervalMs, runImmediately })` runs recurring ingestion for a feed on an interval, with `stopSchedule()` / `stopAllSchedules()` / `isScheduled()` for lifecycle control.

Follows the same plain-class-plus-interfaces style already used by `src/modules/detection/malicious-addresses`.

## Testing
16 new unit tests in `threat-intelligence.service.spec.ts` covering feed registration/removal, successful and failed ingestion (including isolation of per-feed failures), aggregate ingestion, subscriber notifications, and scheduling (interval firing, immediate run, stop/replace/stop-all, scheduling an unregistered feed).

Verified locally:
- `npm run lint` — clean
- `npm run format:check` — clean for these files
- `npm run build` — passes
- `npx jest --config jest.backend.config.js src/modules/threat-intelligence` — 16/16 passing

## Acceptance Criteria
- [x] Framework implemented
- [x] Feed ingestion working
- [x] Scheduling supported

Closes #123