### PR TITLE
feat: Detect High-Frequency Contract Calls

### DIFF
--- a/src/modules/detection/contracts/high-frequency-calls.module.ts
+++ b/src/modules/detection/contracts/high-frequency-calls.module.ts
@@ -1,0 +1,20 @@
+import { HighFrequencyContractCallsService } from './high-frequency-calls.service';
+import { FrequencyThresholdConfig } from './interfaces/high-frequency-calls.interface';
+
+/**
+ * Module wrapper for high-frequency contract call detection.
+ * Provides a static helper to instantiate the service.
+ */
+export class HighFrequencyContractCallsModule {
+  /** Create and configure a HighFrequencyContractCallsService instance. */
+  static create(defaultThreshold?: FrequencyThresholdConfig): HighFrequencyContractCallsService {
+    return new HighFrequencyContractCallsService(defaultThreshold);
+  }
+}
+
+/** Factory helper function to instantiate the HighFrequencyContractCallsService. */
+export function createHighFrequencyContractCallsService(
+  defaultThreshold?: FrequencyThresholdConfig,
+): HighFrequencyContractCallsService {
+  return new HighFrequencyContractCallsService(defaultThreshold);
+}

--- a/src/modules/detection/contracts/high-frequency-calls.service.spec.ts
+++ b/src/modules/detection/contracts/high-frequency-calls.service.spec.ts
@@ -1,0 +1,219 @@
+import { HighFrequencyContractCallsService } from './high-frequency-calls.service';
+import { FrequencyAlert } from './interfaces/high-frequency-calls.interface';
+
+/** Fixed base epoch so test timestamps are deterministic and offset-based. */
+const BASE = new Date('2026-01-01T00:00:00.000Z').getTime();
+const ts = (offsetMs: number): string => new Date(BASE + offsetMs).toISOString();
+
+describe('HighFrequencyContractCallsService', () => {
+  let service: HighFrequencyContractCallsService;
+
+  beforeEach(() => {
+    service = new HighFrequencyContractCallsService();
+  });
+
+  describe('Configurable Thresholds', () => {
+    it('should use a sensible built-in default when no override is set', () => {
+      expect(service.getThreshold('0xany')).toEqual({
+        windowMs: 60_000,
+        maxCallsPerWindow: 50,
+        baselineWindowCount: 5,
+        baselineSpikeMultiplier: 3,
+      });
+    });
+
+    it('should accept a custom default threshold via the constructor', () => {
+      const custom = new HighFrequencyContractCallsService({
+        windowMs: 5_000,
+        maxCallsPerWindow: 10,
+        baselineWindowCount: 4,
+        baselineSpikeMultiplier: 2,
+      });
+
+      expect(custom.getThreshold('0xany')).toEqual({
+        windowMs: 5_000,
+        maxCallsPerWindow: 10,
+        baselineWindowCount: 4,
+        baselineSpikeMultiplier: 2,
+      });
+    });
+
+    it('should allow overriding the threshold for a single contract without affecting others', () => {
+      service.setThreshold('0xA', { maxCallsPerWindow: 3 });
+
+      expect(service.getThreshold('0xA').maxCallsPerWindow).toBe(3);
+      expect(service.getThreshold('0xB').maxCallsPerWindow).toBe(50);
+    });
+
+    it('should merge partial overrides on top of the previous configuration for that contract', () => {
+      service.setThreshold('0xA', { maxCallsPerWindow: 3 });
+      service.setThreshold('0xA', { windowMs: 1_000 });
+
+      expect(service.getThreshold('0xA')).toMatchObject({
+        maxCallsPerWindow: 3,
+        windowMs: 1_000,
+      });
+    });
+  });
+
+  describe('Frequency Monitoring', () => {
+    it('should track call counts per contract independently', () => {
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(10) });
+      service.recordCall({ contractAddress: '0xB', timestamp: ts(10) });
+
+      expect(service.getCallCount('0xA')).toBe(2);
+      expect(service.getCallCount('0xB')).toBe(1);
+    });
+
+    it('should not alert for normal, low-volume activity', () => {
+      const first = service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      const second = service.recordCall({ contractAddress: '0xA', timestamp: ts(10) });
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+    });
+
+    it('should roll the window and reset the open count once windowMs elapses', () => {
+      service.setThreshold('0xA', { windowMs: 1_000, maxCallsPerWindow: 100 });
+
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(100) });
+      expect(service.getCallCount('0xA')).toBe(2);
+
+      // This call lands 1000ms after the window opened -> rolls to a new window
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(1_000) });
+
+      expect(service.getCallCount('0xA')).toBe(1);
+      expect(service.getWindowHistory('0xA')).toEqual([2]);
+    });
+
+    it('should cap the retained window history at baselineWindowCount', () => {
+      service.setThreshold('0xA', {
+        windowMs: 1_000,
+        maxCallsPerWindow: 100,
+        baselineWindowCount: 2,
+      });
+
+      // Four windows' worth of calls -> only the last 2 closed windows are retained
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(1_000) }); // closes window 1 (count 1)
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(2_000) }); // closes window 2 (count 1)
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(3_000) }); // closes window 3 (count 1)
+
+      expect(service.getWindowHistory('0xA')).toEqual([1, 1]);
+    });
+  });
+
+  describe('Threshold Detection', () => {
+    it('should generate a threshold_exceeded alert once calls exceed the absolute cap', () => {
+      service.setThreshold('0xA', {
+        windowMs: 10_000,
+        maxCallsPerWindow: 3,
+        baselineSpikeMultiplier: 999, // effectively disable baseline detection for this test
+      });
+
+      let lastAlert: FrequencyAlert | null = null;
+      for (let i = 0; i < 4; i++) {
+        lastAlert = service.recordCall({ contractAddress: '0xA', timestamp: ts(i * 10) });
+      }
+
+      expect(lastAlert).not.toBeNull();
+      expect(lastAlert?.metadata.reason).toBe('threshold_exceeded');
+      expect(lastAlert?.metadata.callCount).toBe(4);
+      expect(lastAlert?.metadata.threshold).toBe(3);
+      expect(lastAlert?.severity).toBe('critical');
+    });
+
+    it('should not alert while calls stay at or below the threshold', () => {
+      service.setThreshold('0xA', { windowMs: 10_000, maxCallsPerWindow: 3 });
+
+      const results = [0, 10, 20].map(offset =>
+        service.recordCall({ contractAddress: '0xA', timestamp: ts(offset) }),
+      );
+
+      expect(results.every(r => r === null)).toBe(true);
+    });
+  });
+
+  describe('Baseline Comparison', () => {
+    it('should generate a baseline_spike alert when a window far exceeds the rolling average', () => {
+      service.setThreshold('0xA', {
+        windowMs: 1_000,
+        maxCallsPerWindow: 100, // high enough that only the baseline rule can fire
+        baselineWindowCount: 3,
+        baselineSpikeMultiplier: 3,
+      });
+
+      // Two closed windows of 2 calls each, plus a currently-open third window
+      // with matching volume -> a consistent "normal" rate of 2 calls/window
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(100) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(1_000) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(1_100) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(2_000) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(2_100) });
+
+      expect(service.getBaselineAverage('0xA')).toBe(2);
+
+      // Window 4 opens; baseline average is 2, so anything over 2*3=6 should spike
+      let lastAlert: FrequencyAlert | null = null;
+      for (const offset of [3_000, 3_050, 3_100, 3_150, 3_200, 3_250, 3_300]) {
+        lastAlert = service.recordCall({ contractAddress: '0xA', timestamp: ts(offset) });
+      }
+
+      expect(lastAlert).not.toBeNull();
+      expect(lastAlert?.metadata.reason).toBe('baseline_spike');
+      expect(lastAlert?.metadata.callCount).toBe(7);
+      expect(lastAlert?.metadata.baselineAverage).toBe(2);
+      expect(lastAlert?.severity).toBe('high');
+    });
+
+    it('should report no baseline until at least one window has closed', () => {
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+
+      expect(service.getBaselineAverage('0xA')).toBeNull();
+    });
+  });
+
+  describe('Alert Generation', () => {
+    it('should notify subscribers when an alert is raised', () => {
+      service.setThreshold('0xA', { windowMs: 10_000, maxCallsPerWindow: 1 });
+
+      const alerts: FrequencyAlert[] = [];
+      service.onAlert(alert => alerts.push(alert));
+
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(10) });
+
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].metadata.contractAddress).toBe('0xA');
+    });
+
+    it('should stop notifying a subscriber after it unsubscribes', () => {
+      service.setThreshold('0xA', { windowMs: 10_000, maxCallsPerWindow: 1 });
+
+      const alerts: FrequencyAlert[] = [];
+      const unsubscribe = service.onAlert(alert => alerts.push(alert));
+      unsubscribe();
+
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(10) });
+
+      expect(alerts).toHaveLength(0);
+    });
+  });
+
+  describe('clearContract', () => {
+    it('should reset threshold overrides, counts, and history for a contract', () => {
+      service.setThreshold('0xA', { maxCallsPerWindow: 3 });
+      service.recordCall({ contractAddress: '0xA', timestamp: ts(0) });
+
+      service.clearContract('0xA');
+
+      expect(service.getThreshold('0xA').maxCallsPerWindow).toBe(50);
+      expect(service.getCallCount('0xA')).toBe(0);
+      expect(service.getWindowHistory('0xA')).toEqual([]);
+    });
+  });
+});

--- a/src/modules/detection/contracts/high-frequency-calls.service.ts
+++ b/src/modules/detection/contracts/high-frequency-calls.service.ts
@@ -1,0 +1,184 @@
+import {
+  ContractCallEvent,
+  FrequencyAlert,
+  FrequencyAlertReason,
+  FrequencyThresholdConfig,
+} from './interfaces/high-frequency-calls.interface';
+
+const DEFAULT_THRESHOLD: FrequencyThresholdConfig = {
+  windowMs: 60_000,
+  maxCallsPerWindow: 50,
+  baselineWindowCount: 5,
+  baselineSpikeMultiplier: 3,
+};
+
+/**
+ * Detects abnormal spikes in per-contract call activity.
+ *
+ * Two independent detection rules run on every recorded call:
+ *  - Threshold: the current window's call count exceeds a configurable
+ *    absolute cap.
+ *  - Baseline: the current window's call count exceeds a configurable
+ *    multiple of the rolling average of recent closed windows.
+ */
+export class HighFrequencyContractCallsService {
+  private thresholds = new Map<string, FrequencyThresholdConfig>();
+  /** Timestamps (ms epoch) of calls within the current, still-open window. */
+  private callTimestamps = new Map<string, number[]>();
+  /** Call counts of recently closed windows, oldest first. */
+  private windowHistory = new Map<string, number[]>();
+  /** Start time (ms epoch) of the current window. */
+  private windowStart = new Map<string, number>();
+  private alertCallbacks: Array<(alert: FrequencyAlert) => void> = [];
+
+  constructor(private readonly defaultThreshold: FrequencyThresholdConfig = DEFAULT_THRESHOLD) {}
+
+  /** Set a per-contract threshold configuration, overriding the default. */
+  public setThreshold(contractAddress: string, config: Partial<FrequencyThresholdConfig>): void {
+    const current = this.getThreshold(contractAddress);
+    this.thresholds.set(contractAddress, { ...current, ...config });
+  }
+
+  /** The effective threshold configuration for a contract (or the default). */
+  public getThreshold(contractAddress: string): FrequencyThresholdConfig {
+    return this.thresholds.get(contractAddress) ?? this.defaultThreshold;
+  }
+
+  /**
+   * Record an observed contract call, rolling the sliding window forward if
+   * needed, and running both detection rules against the updated count.
+   * Returns the generated alert, or `null` if activity looks normal.
+   */
+  public recordCall(event: ContractCallEvent): FrequencyAlert | null {
+    const { contractAddress } = event;
+    const now = event.timestamp ? new Date(event.timestamp).getTime() : Date.now();
+    const config = this.getThreshold(contractAddress);
+
+    this.rollWindowIfNeeded(contractAddress, now, config);
+
+    const timestamps = this.callTimestamps.get(contractAddress) ?? [];
+    timestamps.push(now);
+    this.callTimestamps.set(contractAddress, timestamps);
+
+    const callCount = timestamps.length;
+
+    if (callCount > config.maxCallsPerWindow) {
+      return this.raiseAlert(contractAddress, 'threshold_exceeded', callCount, config);
+    }
+
+    const baselineAverage = this.getBaselineAverage(contractAddress, config);
+    if (baselineAverage !== null && callCount > baselineAverage * config.baselineSpikeMultiplier) {
+      return this.raiseAlert(contractAddress, 'baseline_spike', callCount, config, baselineAverage);
+    }
+
+    return null;
+  }
+
+  /** Number of calls observed for a contract in the current, open window. */
+  public getCallCount(contractAddress: string): number {
+    return this.callTimestamps.get(contractAddress)?.length ?? 0;
+  }
+
+  /** Call counts of recently closed windows for a contract, oldest first. */
+  public getWindowHistory(contractAddress: string): number[] {
+    return [...(this.windowHistory.get(contractAddress) ?? [])];
+  }
+
+  /** Rolling baseline average across recently closed windows, or `null` if none yet. */
+  public getBaselineAverage(
+    contractAddress: string,
+    config: FrequencyThresholdConfig = this.getThreshold(contractAddress),
+  ): number | null {
+    const history = this.windowHistory.get(contractAddress);
+    if (!history || history.length === 0) {
+      return null;
+    }
+    const recent = history.slice(-config.baselineWindowCount);
+    return recent.reduce((sum, count) => sum + count, 0) / recent.length;
+  }
+
+  /** Clear all tracked state (threshold, counts, history) for a contract. */
+  public clearContract(contractAddress: string): void {
+    this.thresholds.delete(contractAddress);
+    this.callTimestamps.delete(contractAddress);
+    this.windowHistory.delete(contractAddress);
+    this.windowStart.delete(contractAddress);
+  }
+
+  /** Subscribe to generated alerts. Returns an unsubscribe function. */
+  public onAlert(callback: (alert: FrequencyAlert) => void): () => void {
+    this.alertCallbacks.push(callback);
+    return () => {
+      this.alertCallbacks = this.alertCallbacks.filter(cb => cb !== callback);
+    };
+  }
+
+  private rollWindowIfNeeded(
+    contractAddress: string,
+    now: number,
+    config: FrequencyThresholdConfig,
+  ): void {
+    const start = this.windowStart.get(contractAddress);
+
+    if (start === undefined) {
+      this.windowStart.set(contractAddress, now);
+      return;
+    }
+
+    if (now - start >= config.windowMs) {
+      const closedCount = this.callTimestamps.get(contractAddress)?.length ?? 0;
+      const history = this.windowHistory.get(contractAddress) ?? [];
+      history.push(closedCount);
+      while (history.length > config.baselineWindowCount) {
+        history.shift();
+      }
+      this.windowHistory.set(contractAddress, history);
+
+      this.callTimestamps.set(contractAddress, []);
+      this.windowStart.set(contractAddress, now);
+    }
+  }
+
+  private raiseAlert(
+    contractAddress: string,
+    reason: FrequencyAlertReason,
+    callCount: number,
+    config: FrequencyThresholdConfig,
+    baselineAverage?: number,
+  ): FrequencyAlert {
+    const description =
+      reason === 'threshold_exceeded'
+        ? `Contract ${contractAddress} received ${callCount} calls in the last ${config.windowMs}ms window, exceeding the configured cap of ${config.maxCallsPerWindow}.`
+        : `Contract ${contractAddress} received ${callCount} calls in the last ${config.windowMs}ms window, ${(callCount / (baselineAverage ?? 1)).toFixed(1)}x its rolling baseline of ${(baselineAverage ?? 0).toFixed(1)}.`;
+
+    const alert: FrequencyAlert = {
+      id: `alert-hfc-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      title: 'High-Frequency Contract Call Activity Detected',
+      description,
+      severity: reason === 'threshold_exceeded' ? 'critical' : 'high',
+      timestamp: new Date().toISOString(),
+      metadata: {
+        contractAddress,
+        reason,
+        callCount,
+        windowMs: config.windowMs,
+        threshold: config.maxCallsPerWindow,
+        ...(baselineAverage !== undefined && { baselineAverage }),
+      },
+    };
+
+    this.emitAlert(alert);
+    return alert;
+  }
+
+  private emitAlert(alert: FrequencyAlert): void {
+    for (const callback of this.alertCallbacks) {
+      try {
+        callback(alert);
+      } catch (error) {
+        // Prevent one faulty callback from aborting others
+        console.error('Error in high-frequency contract call alert callback:', error);
+      }
+    }
+  }
+}

--- a/src/modules/detection/contracts/interfaces/high-frequency-calls.interface.ts
+++ b/src/modules/detection/contracts/interfaces/high-frequency-calls.interface.ts
@@ -1,0 +1,57 @@
+/** A single observed call/interaction against a monitored contract. */
+export interface ContractCallEvent {
+  /** The contract address that was called. */
+  contractAddress: string;
+  /** ISO-8601 timestamp of the call. Defaults to now if omitted. */
+  timestamp?: string;
+  /** Transaction hash associated with this call, if known. */
+  txHash?: string;
+  /** Network the call occurred on. */
+  network?: string;
+}
+
+/**
+ * Frequency-monitoring configuration for a contract (or the global default).
+ */
+export interface FrequencyThresholdConfig {
+  /** Size of the sliding window used to count calls, in milliseconds. */
+  windowMs: number;
+  /** Absolute cap on calls within one window before an alert fires. */
+  maxCallsPerWindow: number;
+  /** How many past closed windows to retain for the rolling baseline. */
+  baselineWindowCount: number;
+  /**
+   * How many times above the rolling baseline average the current window's
+   * count must be to be considered a spike.
+   */
+  baselineSpikeMultiplier: number;
+}
+
+/** Which detection rule triggered a given alert. */
+export type FrequencyAlertReason = 'threshold_exceeded' | 'baseline_spike';
+
+/** An alert generated when a contract's call frequency looks abnormal. */
+export interface FrequencyAlert {
+  /** Unique alert identifier. */
+  id: string;
+  /** Brief title for the alert. */
+  title: string;
+  /** Detailed description of the detected activity. */
+  description: string;
+  /** Alert severity. */
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  /** ISO-8601 timestamp of when the alert was generated. */
+  timestamp: string;
+  /** Structured context/metadata about the detection. */
+  metadata: {
+    contractAddress: string;
+    reason: FrequencyAlertReason;
+    /** Number of calls observed in the current (still-open) window. */
+    callCount: number;
+    windowMs: number;
+    /** Absolute threshold in effect at detection time. */
+    threshold: number;
+    /** Rolling baseline average, present only for `baseline_spike` alerts. */
+    baselineAverage?: number;
+  };
+}


### PR DESCRIPTION
## What
Implements high-frequency contract call detection requested in #150, under `src/modules/detection/contracts/`.

## Why
Exploits often generate abnormal transaction volume against a contract before or during an attack. This gives Sentinel a way to flag that volume in near real time.

## Implementation
`HighFrequencyContractCallsService` runs two independent detection rules on every recorded call:

- **Frequency monitoring** — `recordCall()` tracks calls per contract in a sliding, tumbling window (`getCallCount()` / `getWindowHistory()` expose the current and recently-closed window counts).
- **Baseline comparison** — a rolling average is kept across the last `baselineWindowCount` closed windows (`getBaselineAverage()`). If the current window's count exceeds that average by `baselineSpikeMultiplier`x, a `baseline_spike` alert fires — this catches sustained-but-abnormal activity even when it stays under the absolute cap.
- **Alert generation** — `onAlert()` lets subscribers observe `FrequencyAlert`s (with an unsubscribe function), each carrying the triggering reason, call count, threshold, and (for baseline alerts) the baseline average.
- **Configurable thresholds** — a default `FrequencyThresholdConfig` (window size, absolute cap, baseline window count, spike multiplier) can be set via the constructor, and overridden per contract with `setThreshold()`/`getThreshold()`. `clearContract()` resets all tracked state for a contract.

Follows the same plain-class-plus-interfaces style already used by `src/modules/detection/malicious-addresses`.

## Testing
15 new unit tests in `high-frequency-calls.service.spec.ts`, using explicit event timestamps (no real-time waiting or fake timers needed) covering: per-contract threshold configuration and overrides, window rolling/history capping, absolute-threshold alerts, baseline-spike alerts, no-alert-on-normal-activity, subscriber notification/unsubscription, and state reset via `clearContract`.

Verified locally:
- `npm run lint` — clean
- `npm run format:check` — clean for these files
- `npm run build` — passes
- `npx jest --config jest.backend.config.js src/modules/detection/contracts` — 15/15 passing
- Full `src/modules` suite — 70/70 passing (no regressions)

## Acceptance Criteria
- [x] Activity spikes detected
- [x] Alerts generated
- [x] Thresholds configurable

Closes #150