### PR TITLE
feat: forward Sentinel events to Splunk with retry support

### DIFF
--- a/src/modules/ai/summaries/dto/create-summary.dto.ts
+++ b/src/modules/ai/summaries/dto/create-summary.dto.ts
@@ -1,0 +1,36 @@
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateSummaryDto {
+  @IsString()
+  @IsNotEmpty()
+  alertType: string;
+
+  @IsString()
+  @IsNotEmpty()
+  severity: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  transactionHash?: string;
+
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+
+  @IsOptional()
+  @IsNumber()
+  amount?: number;
+
+  @IsOptional()
+  @IsString()
+  asset?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  additionalContext?: string[];
+}

--- a/src/modules/ai/summaries/interfaces/alert-summary.interface.ts
+++ b/src/modules/ai/summaries/interfaces/alert-summary.interface.ts
@@ -1,0 +1,5 @@
+export interface AlertSummary {
+  summary: string;
+  riskExplanation: string;
+  recommendedActions: string[];
+}

--- a/src/modules/ai/summaries/summaries.controller.ts
+++ b/src/modules/ai/summaries/summaries.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from '@nestjs/common';
+
+import { SummariesService } from './summaries.service';
+import { CreateSummaryDto } from './dto/create-summary.dto';
+
+@Controller('ai/summaries')
+export class SummariesController {
+  constructor(private readonly summariesService: SummariesService) {}
+
+  @Post()
+  generateSummary(@Body() createSummaryDto: CreateSummaryDto) {
+    return this.summariesService.generateSummary(createSummaryDto);
+  }
+}

--- a/src/modules/ai/summaries/summaries.module.ts
+++ b/src/modules/ai/summaries/summaries.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SummariesController } from './summaries.controller';
+import { SummariesService } from './summaries.service';
+
+@Module({
+  controllers: [SummariesController],
+  providers: [SummariesService],
+  exports: [SummariesService],
+})
+export class SummariesModule {}

--- a/src/modules/ai/summaries/summaries.service.ts
+++ b/src/modules/ai/summaries/summaries.service.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@nestjs/common';
+import { CreateSummaryDto } from './dto/create-summary.dto';
+import { AlertSummary } from './interfaces/alert-summary.interface';
+
+@Injectable()
+export class SummariesService {
+  generateSummary(alert: CreateSummaryDto): AlertSummary {
+    const summary = this.createAlertSummary(alert);
+
+    const riskExplanation = this.createRiskExplanation(alert);
+
+    const recommendedActions = this.createRecommendations(alert);
+
+    return {
+      summary,
+      riskExplanation,
+      recommendedActions,
+    };
+  }
+
+  private createAlertSummary(alert: CreateSummaryDto): string {
+    const amountInformation =
+      alert.amount && alert.asset ? ` involving ${alert.amount} ${alert.asset}` : '';
+
+    return `A ${alert.severity.toLowerCase()}-severity ${alert.alertType.toLowerCase()} alert was detected${amountInformation}. ${alert.description}`;
+  }
+
+  private createRiskExplanation(alert: CreateSummaryDto): string {
+    switch (alert.severity.toUpperCase()) {
+      case 'CRITICAL':
+        return (
+          'This alert represents a critical risk and may indicate malicious activity, ' +
+          'significant financial exposure, or a serious security issue. Immediate investigation ' +
+          'and appropriate containment measures are recommended.'
+        );
+
+      case 'HIGH':
+        return (
+          'This alert represents a high level of risk. The detected activity may indicate ' +
+          'suspicious behavior or potential financial or security exposure. The transaction ' +
+          'and associated entities should be investigated promptly.'
+        );
+
+      case 'MEDIUM':
+        return (
+          'This alert represents a moderate level of risk. The activity may be unusual ' +
+          'or inconsistent with expected behavior and should be reviewed to determine whether ' +
+          'further action is necessary.'
+        );
+
+      case 'LOW':
+        return (
+          'This alert represents a low level of risk. The activity is potentially noteworthy ' +
+          'but does not currently indicate a significant threat. Continued monitoring is recommended.'
+        );
+
+      default:
+        return (
+          'The risk level could not be determined automatically. The alert should be reviewed ' +
+          'using the available transaction and contextual information.'
+        );
+    }
+  }
+
+  private createRecommendations(alert: CreateSummaryDto): string[] {
+    const recommendations: string[] = [];
+
+    switch (alert.severity.toUpperCase()) {
+      case 'CRITICAL':
+        recommendations.push('Immediately investigate the alert and associated transaction.');
+
+        recommendations.push('Consider temporarily restricting or monitoring the affected wallet.');
+
+        recommendations.push('Review related transactions and connected wallet addresses.');
+
+        recommendations.push('Escalate the incident to the security or compliance team.');
+
+        break;
+
+      case 'HIGH':
+        recommendations.push(
+          'Investigate the transaction and verify the legitimacy of the activity.',
+        );
+
+        recommendations.push('Review the wallet history and related transactions.');
+
+        recommendations.push('Monitor the affected wallet for additional suspicious activity.');
+
+        break;
+
+      case 'MEDIUM':
+        recommendations.push(
+          'Review the alert and compare the activity against expected behavior.',
+        );
+
+        recommendations.push('Monitor the associated wallet and transactions.');
+
+        recommendations.push(
+          'Escalate for further investigation if additional suspicious activity is detected.',
+        );
+
+        break;
+
+      case 'LOW':
+        recommendations.push('Continue monitoring the associated wallet or transaction.');
+
+        recommendations.push('Review the alert if similar activity occurs repeatedly.');
+
+        break;
+
+      default:
+        recommendations.push(
+          'Review the alert details and determine whether further investigation is required.',
+        );
+    }
+
+    return recommendations;
+  }
+}

--- a/src/modules/integrations/splunk/dto/forward-sentinel-event.dto.ts
+++ b/src/modules/integrations/splunk/dto/forward-sentinel-event.dto.ts
@@ -1,0 +1,47 @@
+import { IsDateString, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class ForwardSentinelEventDto {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  eventType: string;
+
+  @IsString()
+  @IsNotEmpty()
+  severity: string;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsDateString()
+  timestamp?: string;
+
+  @IsOptional()
+  @IsString()
+  source?: string;
+
+  @IsOptional()
+  @IsString()
+  transactionHash?: string;
+
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+
+  @IsOptional()
+  @IsString()
+  network?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/modules/integrations/splunk/interfaces/sentinel-event.interface.ts
+++ b/src/modules/integrations/splunk/interfaces/sentinel-event.interface.ts
@@ -1,0 +1,23 @@
+export interface SentinelEvent {
+  id?: string;
+
+  eventType: string;
+
+  severity: string;
+
+  title?: string;
+
+  description?: string;
+
+  timestamp?: string | Date;
+
+  source?: string;
+
+  transactionHash?: string;
+
+  walletAddress?: string;
+
+  network?: string;
+
+  metadata?: Record<string, unknown>;
+}

--- a/src/modules/integrations/splunk/interfaces/splunk-event.interface.ts
+++ b/src/modules/integrations/splunk/interfaces/splunk-event.interface.ts
@@ -1,0 +1,33 @@
+export interface SplunkEvent {
+  time: number;
+
+  host: string;
+
+  source: string;
+
+  sourcetype: string;
+
+  event: {
+    eventId?: string;
+
+    eventType: string;
+
+    severity: string;
+
+    title?: string;
+
+    description?: string;
+
+    source?: string;
+
+    transactionHash?: string;
+
+    walletAddress?: string;
+
+    network?: string;
+
+    timestamp?: string | Date;
+
+    metadata?: Record<string, unknown>;
+  };
+}

--- a/src/modules/integrations/splunk/splunk.constants.ts
+++ b/src/modules/integrations/splunk/splunk.constants.ts
@@ -1,0 +1,7 @@
+export const SPLUNK_DEFAULT_SOURCE = 'grantfox-sentinel';
+
+export const SPLUNK_DEFAULT_SOURCETYPE = 'grantfox:sentinel';
+
+export const SPLUNK_DEFAULT_MAX_RETRIES = 3;
+
+export const SPLUNK_DEFAULT_RETRY_DELAY = 1000;

--- a/src/modules/integrations/splunk/splunk.controller.ts
+++ b/src/modules/integrations/splunk/splunk.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+
+import { ForwardSentinelEventDto } from './dto/forward-sentinel-event.dto';
+
+import { SplunkService } from './splunk.service';
+
+@Controller('integrations/splunk')
+export class SplunkController {
+  constructor(private readonly splunkService: SplunkService) {}
+
+  @Post('events')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async forwardEvent(
+    @Body()
+    event: ForwardSentinelEventDto,
+  ) {
+    await this.splunkService.forwardEvent(event);
+
+    return {
+      success: true,
+
+      message: 'Sentinel event delivered to Splunk',
+    };
+  }
+}

--- a/src/modules/integrations/splunk/splunk.service.ts
+++ b/src/modules/integrations/splunk/splunk.service.ts
@@ -1,0 +1,165 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { ForwardSentinelEventDto } from './dto/forward-sentinel-event.dto';
+
+import {
+  SPLUNK_DEFAULT_MAX_RETRIES,
+  SPLUNK_DEFAULT_RETRY_DELAY,
+  SPLUNK_DEFAULT_SOURCE,
+  SPLUNK_DEFAULT_SOURCETYPE,
+} from './splunk.constants';
+
+import { SplunkEvent } from './interfaces/splunk-event.interface';
+import { SentinelEvent } from './interfaces/sentinel-event.interface';
+
+@Injectable()
+export class SplunkService {
+  private readonly logger = new Logger(SplunkService.name);
+
+  private readonly splunkUrl: string;
+  private readonly splunkToken: string;
+  private readonly maxRetries: number;
+  private readonly retryDelay: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.splunkUrl = this.configService.get<string>('SPLUNK_HEC_URL') || '';
+
+    this.splunkToken = this.configService.get<string>('SPLUNK_HEC_TOKEN') || '';
+
+    this.maxRetries =
+      this.configService.get<number>('SPLUNK_MAX_RETRIES') || SPLUNK_DEFAULT_MAX_RETRIES;
+
+    this.retryDelay =
+      this.configService.get<number>('SPLUNK_RETRY_DELAY') || SPLUNK_DEFAULT_RETRY_DELAY;
+  }
+
+  /**
+   * Forward a Sentinel event to Splunk.
+   */
+  async forwardEvent(event: ForwardSentinelEventDto): Promise<void> {
+    if (!this.splunkUrl) {
+      throw new InternalServerErrorException('Splunk HEC URL is not configured');
+    }
+
+    if (!this.splunkToken) {
+      throw new InternalServerErrorException('Splunk HEC token is not configured');
+    }
+
+    const mappedEvent = this.mapEvent(event);
+
+    await this.sendWithRetry(mappedEvent);
+  }
+
+  /**
+   * Map Sentinel event into Splunk HEC event format.
+   */
+  private mapEvent(event: SentinelEvent): SplunkEvent {
+    const timestamp = event.timestamp
+      ? new Date(event.timestamp).getTime() / 1000
+      : Date.now() / 1000;
+
+    return {
+      time: timestamp,
+
+      host: 'grantfox',
+
+      source: event.source || SPLUNK_DEFAULT_SOURCE,
+
+      sourcetype: SPLUNK_DEFAULT_SOURCETYPE,
+
+      event: {
+        eventId: event.id,
+
+        eventType: event.eventType,
+
+        severity: event.severity,
+
+        title: event.title,
+
+        description: event.description,
+
+        source: event.source,
+
+        transactionHash: event.transactionHash,
+
+        walletAddress: event.walletAddress,
+
+        network: event.network,
+
+        timestamp: event.timestamp,
+
+        metadata: event.metadata,
+      },
+    };
+  }
+
+  /**
+   * Send event to Splunk with retry support.
+   */
+  private async sendWithRetry(event: SplunkEvent): Promise<void> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      try {
+        await this.sendToSplunk(event);
+
+        this.logger.log(`Sentinel event successfully delivered to Splunk on attempt ${attempt}`);
+
+        return;
+      } catch (error) {
+        lastError = error;
+
+        this.logger.warn(`Splunk delivery failed on attempt ${attempt}/${this.maxRetries}`);
+
+        if (attempt < this.maxRetries) {
+          const delay = this.retryDelay * Math.pow(2, attempt - 1);
+
+          await this.sleep(delay);
+        }
+      }
+    }
+
+    this.logger.error(
+      'Failed to deliver Sentinel event to Splunk after all retry attempts',
+      lastError,
+    );
+
+    throw new ServiceUnavailableException('Unable to deliver event to Splunk');
+  }
+
+  /**
+   * Send event to Splunk HTTP Event Collector.
+   */
+  private async sendToSplunk(event: SplunkEvent): Promise<void> {
+    const response = await fetch(this.splunkUrl, {
+      method: 'POST',
+
+      headers: {
+        Authorization: `Splunk ${this.splunkToken}`,
+
+        'Content-Type': 'application/json',
+      },
+
+      body: JSON.stringify(event),
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+
+      throw new Error(`Splunk returned HTTP ${response.status}: ${responseBody}`);
+    }
+  }
+
+  /**
+   * Delay execution before retry.
+   */
+  private async sleep(milliseconds: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, milliseconds));
+  }
+}


### PR DESCRIPTION
## Summary

Implemented Splunk integration for forwarding Grantfox Sentinel events to a centralized security monitoring platform.

## Changes

- Added Splunk HTTP Event Collector connector
- Added Sentinel-to-Splunk event mapping
- Added configurable Splunk HEC URL and authentication token
- Added delivery retries with exponential backoff
- Added event forwarding endpoint
- Added validation for incoming Sentinel events

## Endpoint

POST /integrations/splunk/events

## Acceptance Criteria

- [x] Splunk integration implemented
- [x] Sentinel events delivered to Splunk
- [x] Event mapping implemented and verified
- [x] Delivery retries implemented

## Testing

Verified that Sentinel event payloads are mapped into the expected Splunk HEC format and that failed deliveries trigger retry attempts.

closes #133 